### PR TITLE
Add Sass variable for RTL support.

### DIFF
--- a/sass/no-mq.scss
+++ b/sass/no-mq.scss
@@ -2,6 +2,7 @@
 $legacy-support-for-ie6: false;
 $legacy-support-for-ie7: false;
 $legacy-support-for-ie8: true;
+$support-for-rtl: true;
 
 @import 'breakpoint-sass/stylesheets/breakpoint'; // github.com/Team-Sass/breakpoint
 // Don't print media queries & print no query fallbacks.

--- a/sass/partials/base/_html-elements.scss
+++ b/sass/partials/base/_html-elements.scss
@@ -246,9 +246,11 @@ legend {
   @if $legacy-support-for-ie6 or $legacy-support-for-ie7 {
     *margin-left: -7px; // LTR
 
-    [dir="rtl"] & {
-      *margin-left: 0;
-      *margin-right: -7px;
+    @if $support-for-rtl {
+      [dir="rtl"] & {
+        *margin-left: 0;
+        *margin-right: -7px;
+      }
     }
   }
 }
@@ -276,8 +278,10 @@ ol {
   margin: 0 0 1.5em;
   padding: 0 0 0 1.5em; // LTR
 
-  [dir="rtl"] & {
-    padding: 0 1.5em 0 0;
+  @if $support-for-rtl {
+    [dir="rtl"] & {
+      padding: 0 1.5em 0 0;
+    }
   }
 
   ol,
@@ -367,8 +371,10 @@ ul {
   margin: 0 0 1.5em;
   padding: 0 0 0 1.2em; // LTR
 
-  [dir="rtl"] & {
-    padding: 0 1.2em 0 0;
+  @if $support-for-rtl {
+    [dir="rtl"] & {
+      padding: 0 1.2em 0 0;
+    }
   }
 
   ol,

--- a/sass/partials/components/_messages.scss
+++ b/sass/partials/components/_messages.scss
@@ -13,17 +13,21 @@
   position: relative;
   word-wrap: break-word;
 
-  [dir="rtl"] & {
-    background-position: 98.5% 50%;
-    padding: 0.75em 3em 0.75em 0.75em;
+  @if $support-for-rtl {
+    [dir="rtl"] & {
+      background-position: 98.5% 50%;
+      padding: 0.75em 3em 0.75em 0.75em;
+    }
   }
 
   @media print {
     background-image: none !important;
     padding-left: 0.75em; // LTR
 
-    [dir="rtl"] & {
-      padding-right: 0.75em;
+    @if $support-for-rtl {
+      [dir="rtl"] & {
+        padding-right: 0.75em;
+      }
     }
   }
 

--- a/sass/partials/components/_nav.scss
+++ b/sass/partials/components/_nav.scss
@@ -28,8 +28,10 @@
       float: left; // LTR
       margin: 0 0 0.1em 0;
 
-      [dir="rtl"] & {
-        float: right;
+      @if $support-for-rtl {
+        [dir="rtl"] & {
+          float: right;
+        }
       }
     }
   }
@@ -86,11 +88,13 @@
       border-bottom-left-radius: 5px; // LTR
       border-top-right-radius: 0; // LTR
 
-      [dir="rtl"] & {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 5px;
-        border-top-left-radius: 0;
-        border-top-right-radius: 5px;
+      @if $support-for-rtl {
+        [dir="rtl"] & {
+          border-bottom-left-radius: 0;
+          border-bottom-right-radius: 5px;
+          border-top-left-radius: 0;
+          border-top-right-radius: 5px;
+        }
       }
     }
   }
@@ -103,11 +107,13 @@
       border-bottom-left-radius: 0; // LTR
       border-top-right-radius: 5px; // LTR
 
-      [dir="rtl"] & {
-        border-bottom-left-radius: 5px;
-        border-bottom-right-radius: 0;
-        border-top-left-radius: 5px;
-        border-top-right-radius: 0;
+      @if $support-for-rtl {
+        [dir="rtl"] & {
+          border-bottom-left-radius: 5px;
+          border-bottom-right-radius: 0;
+          border-top-left-radius: 5px;
+          border-top-right-radius: 0;
+        }
       }
     }
   }
@@ -124,14 +130,16 @@
     margin-right: 0.75em; // LTR
     padding-right: 0.75em; // LTR
 
-    [dir="rtl"] & {
-      border-left: 1px solid $pipeline-border-color;
-      border-right: 0;
-      float: right;
-      margin-left: 0.75em;
-      margin-right: 0;
-      padding-left: 0.75em;
-      padding-right: 0;
+    @if $support-for-rtl {
+      [dir="rtl"] & {
+        border-left: 1px solid $pipeline-border-color;
+        border-right: 0;
+        float: right;
+        margin-left: 0.75em;
+        margin-right: 0;
+        padding-left: 0.75em;
+        padding-right: 0;
+      }
     }
 
     &:last-child {
@@ -139,10 +147,12 @@
       margin-right: 0; // LTR
       padding-right: 0; // LTR
 
-      [dir="rtl"] & {
-        border-left: 0;
-        margin-left: 0;
-        padding-left: 0;
+      @if $support-for-rtl {
+        [dir="rtl"] & {
+          border-left: 0;
+          margin-left: 0;
+          padding-left: 0;
+        }
       }
     }
   }

--- a/sass/partials/components/_progress-bar.scss
+++ b/sass/partials/components/_progress-bar.scss
@@ -40,16 +40,20 @@
 .progress__description {
   float: left; // LTR
 
-  [dir="rtl"] & {
-    float: right;
+  @if $support-for-rtl {
+    [dir="rtl"] & {
+      float: right;
+    }
   }
 }
 
 .progress__percentage {
   float: right; // LTR
 
-  [dir="rtl"] & {
-    float: left;
+  @if $support-for-rtl {
+    [dir="rtl"] & {
+      float: left;
+    }
   }
 }
 

--- a/sass/partials/components/nav/_nav--mobile-menu.scss
+++ b/sass/partials/components/nav/_nav--mobile-menu.scss
@@ -73,9 +73,11 @@
       @include svg-background-inline(mobile-arrow-up);
     }
 
-    [dir="rtl"] & {
-      left: 0;
-      right: auto;
+    @if $support-for-rtl {
+      [dir="rtl"] & {
+        left: 0;
+        right: auto;
+      }
     }
   }
 

--- a/sass/partials/global/extendables/_button.scss
+++ b/sass/partials/global/extendables/_button.scss
@@ -47,9 +47,11 @@
   & + & {
     margin-left: 1em; // LTR
 
-    [dir="rtl"] & {
-      margin-left: 0;
-      margin-right: 1em;
+    @if $support-for-rtl {
+      [dir="rtl"] & {
+        margin-left: 0;
+        margin-right: 1em;
+      }
     }
   }
 }

--- a/sass/styles.scss
+++ b/sass/styles.scss
@@ -1,6 +1,7 @@
 $legacy-support-for-ie6: false;
 $legacy-support-for-ie7: false;
 $legacy-support-for-ie8: false;
+$support-for-rtl: true;
 
 @import 'breakpoint-sass/stylesheets/breakpoint'; // github.com/Team-Sass/breakpoint
 @include breakpoint-set('no queries', false);


### PR DESCRIPTION
If we add a Sass variable for RTL support (which defaults to true so that current functionality doesn’t change) we can easily set this to false on individual projects, which will remove all of the RTL-specific styles.
