### PR TITLE
Update visibility classes to match Drupal 8.

### DIFF
--- a/sass/partials/components/_breadcrumb.scss
+++ b/sass/partials/components/_breadcrumb.scss
@@ -6,7 +6,7 @@
 }
 
 .breadcrumb__title {
-  @extend %element-invisible;
+  @extend %visually-hidden;
 }
 
 .breadcrumb__list {

--- a/sass/partials/global/helpers/_accessibility.scss
+++ b/sass/partials/global/helpers/_accessibility.scss
@@ -3,58 +3,66 @@
 
 // Makes an element visually hidden, but accessible.
 // @see http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
-@mixin element-invisible {
-  border: 0;
-  clip: rect(0 0 0 0);
+@mixin visually-hidden {
+  clip: rect(1px, 1px, 1px, 1px);
   height: 1px;
-  margin: -1px;
   overflow: hidden;
-  padding: 0;
   position: absolute;
   width: 1px;
+  word-wrap: normal;
 }
 
-// Turns off the element-invisible effect.
-@mixin element-invisible-off {
+// Turns off the visually-hidden effect.
+@mixin visually-hidden-off {
   clip: auto;
   height: auto;
-  margin: 0;
   overflow: visible;
+  position: static;
   width: auto;
 }
 
 // Makes an element visually hidden by default, but visible when focused.
-@mixin element-focusable {
-  @include element-invisible;
+@mixin focusable {
+  @include visually-hidden;
 
   &:active,
   &:focus {
-    @include element-invisible-off;
+    @include visually-hidden-off;
   }
 }
 
 // Makes an element completely hidden, visually and to screen readers.
-@mixin element-hidden {
+@mixin hidden {
   display: none;
 }
 
-%element-invisible {
-  @include element-invisible;
+// Makes an element completely hidden, visually and to screen readers, but
+// maintains its layout.
+@mixin invisible {
+  visibility: hidden;
 }
 
-%element-invisible-off {
-  @include element-invisible-off;
+%visually-hidden {
+  @include visually-hidden;
 }
 
-%element-focusable {
-  @extend %element-invisible;
+%visually-hidden-off {
+  @include visually-hidden-off;
+}
+
+%focusable {
+  @extend %visually-hidden;
 
   &:active,
   &:focus {
-    @extend %element-invisible-off;
+    @extend %visually-hidden-off;
   }
 }
 
-%element-hidden {
-  @include element-hidden;
+%hidden {
+  @include hidden;
+}
+
+%invisible {
+  @include invisible;
 }

--- a/sass/partials/helper-classes/_accessibility.scss
+++ b/sass/partials/helper-classes/_accessibility.scss
@@ -3,14 +3,18 @@
 //
 // Extended from global/helpers/_accessibility.scss.
 
-.element-invisible {
-  @extend %element-invisible;
+.visually-hidden {
+  @extend %visually-hidden;
 }
 
-.element-focusable {
-  @extend %element-focusable;
+.focusable {
+  @extend %focusable;
 }
 
-.element-hidden {
-  @extend %element-hidden;
+.hidden {
+  @extend %hidden;
+}
+
+.invisible {
+  @extend %invisible;
 }


### PR DESCRIPTION
The accessibility helper classes were still based on the Drupal 7 standard.
