### PR TITLE
updated theme path and tasks to use consistent path structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Gesso",
   "version": "0.1.0",
-  "themePath": "./",
+  "themePath": ".",
   "devDependencies": {
     "grunt": "^0.4.1",
     "grunt-contrib-watch": "^0.6.1",

--- a/tasks/config/sass_globbing.js
+++ b/tasks/config/sass_globbing.js
@@ -3,10 +3,10 @@ module.exports = function (grunt) {
     sass_globbing: {
       gesso: {
         files: (function (grunt) {
-          var opts = grunt.file.readJSON(grunt.config.get('pkg').themePath + 'sass/sass-globbing.json');
+          var opts = grunt.file.readJSON(grunt.config.get('pkg').themePath + '/sass/sass-globbing.json');
 
           return Object.keys(opts).reduce(function (previous, current) {
-            previous[grunt.config.get('pkg').themePath + 'sass/' + current] = grunt.config.get('pkg').themePath + 'sass/' + opts[current];
+            previous[grunt.config.get('pkg').themePath + '/sass/' + current] = grunt.config.get('pkg').themePath + '/sass/' + opts[current];
             return previous;
           }, {});
         })(grunt)


### PR DESCRIPTION
This updates the themePath variable and sass_globbing task to use the same path structure as all other grunt tasks.
