### PR TITLE
changed class name on skiplinks to match new accessibility class name

### DIFF
--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -42,7 +42,7 @@
   </head>
   <body{{ attributes.addClass(body_classes) }}>
     <div class="skiplinks">
-      <a href="#main" class="skiplinks__link element-focusable">{{ 'Skip to main content'|t }}</a>
+      <a href="#main" class="skiplinks__link focusable">{{ 'Skip to main content'|t }}</a>
     </div>
     {{ page_top }}
     {{ page }}


### PR DESCRIPTION
When we changed the accessibility class names, we skipped the skiplinks markup (pun intended).  This updates the class in the skiplinks markup to match the new class name.
