### PR TITLE
Update progress bar

### DIFF
--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -15,7 +15,17 @@ libraries-override:
   system/base:
     css:
       component:
+        /core/themes/stable/css/system/components/align.module.css: false
+        /core/themes/stable/css/system/components/clearfix.module.css: false
+        /core/themes/stable/css/system/components/container-inline.module.css: false
+        /core/themes/stable/css/system/components/fieldgroup.module.css: false
+        /core/themes/stable/css/system/components/hidden.module.css: false
+        /core/themes/stable/css/system/components/item-list.module.css: false
+        /core/themes/stable/css/system/components/nowrap.module.css: false
+        /core/themes/stable/css/system/components/position-container.module.css: false
         /core/themes/stable/css/system/components/progress.module.css: false
+        /core/themes/stable/css/system/components/reset-appearance.module.css: false
+        /core/themes/stable/css/system/components/resize.module.css: false
 
 regions:
   page_top: 'Page top'

--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -12,6 +12,10 @@ libraries-override:
   core/modernizr:
     js:
       assets/vendor/modernizr/modernizr.min.js: js/lib/modernizr.min.js
+  system/base:
+    css:
+      component:
+        /core/themes/stable/css/system/components/progress.module.css: false
 
 regions:
   page_top: 'Page top'

--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -22,3 +22,9 @@ pager:
   css:
     theme:
       css/pager.css: {}
+
+progress:
+  version: VERSION
+  css:
+    theme:
+      css/progress.css: {}

--- a/includes/gesso.drush.inc
+++ b/includes/gesso.drush.inc
@@ -144,6 +144,7 @@ function drush_gesso($name = NULL) {
     $libraries_file,
     $theme_file,
     'js/scripts.js',
+    'templates/misc/progress-bar.html.twig',
     'templates/misc/status-messages.html.twig',
     'templates/navigation/pager.html.twig',
     'templates/views/views-mini-pager.html.twig',

--- a/sass/README.md
+++ b/sass/README.md
@@ -32,9 +32,6 @@ Utility classes that aren’t components themselves, such as clearfix.
 ### partials/_quick-fixes.scss
 Deadlines happen, so put your quick fixes here. Hopefully there will be time later to move/re-factor these styles into their proper place.
 
-### overrides/
-Stylesheets provided by Drupal modules that you want to completely override go here. Please update *.libraries.yml to ensure that the module’s stylesheets are not added and your override stylesheets are added in their place.
-
 ## SMACSS
 
 You should try to abstract your components as much as possible to promote reuse throughout the theme. Components should be flexible enough to respond to any width and should never rely on context (e.g., .sidebar-first .component) for styling. This allows components to be placed anywhere in the markup with no risk of them breaking.

--- a/sass/progress.scss
+++ b/sass/progress.scss
@@ -1,7 +1,10 @@
 // @file
 // Styles for progress bars.
 
-$progress-color: $color-link !default;
+@import 'partials/global';
+$progress-border-radius: rem(3px) !default;
+$progress-color: #aeb0b5 !default;
+$progress-color-bar: $color-link !default;
 $progress-color-border: #5b616b !default;
 
 .progress {
@@ -9,24 +12,21 @@ $progress-color-border: #5b616b !default;
 }
 
 .progress__track {
-  background-color: #fff;
-  background-image: linear-gradient(to bottom, $color-gradient-dark 0%, $color-gradient-light 100%);
+  background-color: $progress-color;
   border: 1px solid $progress-color-border;
-  border-radius: 1em;
+  border-radius: $progress-border-radius;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
-  height: 1em;
-  margin-bottom: 0.25em;
+  height: 1rem;
+  margin: 0.2em 0;
   max-width: 100%;
   min-width: 6em;
   overflow: hidden;
 }
 
 .progress__bar {
-  background-color: lighten($progress-color, 15%);
-  background-image: linear-gradient(to bottom, $color-gradient-light 0%, $color-gradient-dark 100%);
-  border: 1px solid darken($progress-color, 15%);
-  border-radius: 1em;
-  height: 1em;
+  background-color: $progress-color-bar;
+  border-radius: $progress-border-radius;
+  height: 1rem;
   transition-duration: 0.5s;
   transition-property: width;
   transition-timing-function: ease-out;
@@ -36,7 +36,7 @@ $progress-color-border: #5b616b !default;
 .progress__description,
 .progress__percentage {
   color: $color-text-secondary;
-  font-size: em($font-size-xs);
+  font-size: rem($font-size-xs);
   overflow: hidden;
 }
 
@@ -60,12 +60,3 @@ $progress-color-border: #5b616b !default;
   }
 }
 
-.progress--small {
-  .progress__track {
-    height: 0.5em;
-  }
-
-  .progress__bar {
-    height: 0.5em;
-  }
-}

--- a/templates/misc/progress-bar.html.twig
+++ b/templates/misc/progress-bar.html.twig
@@ -1,0 +1,25 @@
+{#
+/**
+ * @file
+ * Theme override for a progress bar.
+ *
+ * Note that the core Batch API uses this only for non-JavaScript batch jobs.
+ *
+ * Available variables:
+ * - label: The label of the working task.
+ * - percent: The percentage of the progress.
+ * - message: A string containing information to be displayed.
+ */
+#}
+{{ attach_library('gesso/progress') }}
+<div class="progress" data-drupal-progress>
+  {% if label %}
+    <div class="progress__label">{{ label }}</div>
+  {% endif %}
+
+  <div class="progress__track">
+    <div class="progress__bar" style="width: {{ percent }}%"></div>
+  </div>
+  <div class="progress__percentage">{{ percent }}%</div>
+  <div class="progress__description">{{ message }}</div>
+</div>


### PR DESCRIPTION
I moved the progress bar sass partial to its own stylesheet that gets pulled in via a library. I removed the unnecessary sass overrides folder since all stylesheets will be in the root sass folder. I also updated gesso.info.yml to prevent Drupal from adding unnecessary core stylesheets.