### PR TITLE
Fix pseudo element selectors

### DIFF
--- a/sass/partials/base/_html-elements.scss
+++ b/sass/partials/base/_html-elements.scss
@@ -2,8 +2,8 @@
 // Default styling of html elements.
 
 *,
-*:before,
-*:after {
+*::before,
+*::after {
   box-sizing: inherit;
 }
 
@@ -436,7 +436,7 @@ video {}
     text-decoration: none;
   }
 
-  a[href]:after {
+  a[href]::after {
     font-family: $base-font-family;
     content: ' <' attr(href) '>';
     font-size: 10pt;
@@ -445,19 +445,19 @@ video {}
   }
 
   // Uncomment and replace example.com with your site’s domain.
-  //a[href^='/']:after {
+  //a[href^='/']::after {
   //  content: ' <http://example.com' attr(href) '>';
   //}
 
-  a[href^='javascript:']:after,
-  a[href^='mailto:']:after,
-  a[href^='tel:']:after,
-  a[href^='#']:after,
-  a[href*='?']:after {
+  a[href^='javascript:']::after,
+  a[href^='mailto:']::after,
+  a[href^='tel:']::after,
+  a[href^='#']::after,
+  a[href*='?']::after {
     content: '';
   }
 
-  abbr[title]:after {
+  abbr[title]::after {
     content: ' (' attr(title) ')';
   }
 
@@ -469,12 +469,12 @@ video {}
     page-break-inside: avoid;
   }
 
-  h1 a:after,
-  h2 a:after,
-  h3 a:after,
-  h4 a:after,
-  h5 a:after,
-  h6 a:after {
+  h1 a::after,
+  h2 a::after,
+  h3 a::after,
+  h4 a::after,
+  h5 a::after,
+  h6 a::after {
     display: inline-block;
   }
 

--- a/sass/partials/base/_normalize.scss
+++ b/sass/partials/base/_normalize.scss
@@ -84,10 +84,10 @@ button::-moz-focus-inner,
   padding: 0;
 }
 
-button:-moz-focusring,
-[type='button']:-moz-focusring,
-[type='reset']:-moz-focusring,
-[type='submit']:-moz-focusring {
+button::-moz-focusring,
+[type='button']::-moz-focusring,
+[type='reset']::-moz-focusring,
+[type='submit']::-moz-focusring {
   outline: 1px dotted ButtonText;
 }
 

--- a/sass/partials/components/_breadcrumb.scss
+++ b/sass/partials/components/_breadcrumb.scss
@@ -19,12 +19,12 @@
   display: inline;
   margin-right: 0.5em;
 
-  &:after {
+  &::after {
     content: '\2794';
     margin-left: 0.5em;
   }
 
-  &:last-child:after {
+  &:last-child::after {
     content: '';
     margin-left: 0;
   }

--- a/sass/partials/components/_form-item.scss
+++ b/sass/partials/components/_form-item.scss
@@ -48,7 +48,7 @@ $form-text-size: $font-size-md !default;
   }
 }
 
-.form-item__required-marker:before {
+.form-item__required-marker::before {
   content: '*';
 }
 
@@ -126,7 +126,7 @@ $form-text-size: $font-size-md !default;
     cursor: pointer;
     display: block;
 
-    &:before {
+    &::before {
       background: #fff;
       border-radius: 50%;
       box-shadow: 0 0 0 2px #ffffff, 0 0 0 3px #757575;
@@ -144,19 +144,19 @@ $form-text-size: $font-size-md !default;
     }
   }
 
-  &:checked + .form-item__label:before {
+  &:checked + .form-item__label::before {
     background-color: #0071bc;
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #0071bc;
   }
 
-  &:focus + .form-item__label:before {
+  &:focus + .form-item__label::before {
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #0071bc, 0 0 3px 4px #3e94cf, 0 0 7px 4px #3e94cf;
   }
 
   &:disabled + .form-item__label {
     color: $color-text-secondary;
 
-    &:before {
+    &::before {
       background-color: $form-color-disabled;
       box-shadow: 0 0 0 1px $form-border-color-disabled;
       cursor: not-allowed;
@@ -165,7 +165,7 @@ $form-text-size: $font-size-md !default;
 }
 
 .form-item__checkbox {
-  & + .form-item__label:before {
+  & + .form-item__label::before {
     border-radius: rem(3px);
     box-shadow: 0 0 0 1px #757575;
     height: rem(18px);
@@ -173,7 +173,7 @@ $form-text-size: $font-size-md !default;
     width: rem(18px);
   }
 
-  &:checked + .form-item__label:before {
+  &:checked + .form-item__label::before {
     @include svg-background(correct);
     background-position: 50%;
     background-repeat: no-repeat;
@@ -181,11 +181,11 @@ $form-text-size: $font-size-md !default;
     box-shadow: 0 0 0 1px #0071bc;
   }
 
-  &:disabled + .form-item__label:before {
+  &:disabled + .form-item__label::before {
     box-shadow: 0 0 0 1px $form-border-color-disabled;
   }
 
-  &:checked:disabled + .form-item__label:before {
+  &:checked:disabled + .form-item__label::before {
     background-color: $form-border-color-disabled;
   }
 }

--- a/sass/partials/global/helpers/_clearfix.scss
+++ b/sass/partials/global/helpers/_clearfix.scss
@@ -2,7 +2,7 @@
 // Clearfix
 
 @mixin clearfix {
-  &:after {
+  &::after {
     clear: both;
     content: '';
     display: table;
@@ -10,7 +10,7 @@
 }
 
 @mixin clearfix-important {
-  &:after {
+  &::after {
     clear: both !important;
     content: '' !important;
     display: table !important;

--- a/sass/partials/global/helpers/_image-replace.scss
+++ b/sass/partials/global/helpers/_image-replace.scss
@@ -8,7 +8,7 @@
   overflow: hidden;
   width: $width;
 
-  &:before {
+  &::before {
     content: '';
     display: block;
     height: 150%;


### PR DESCRIPTION
Now that we’re no longer supporting IE8, we can use :: for pseudo element selectors.