### PR TITLE
Separate out visually-hidden styles from focusable styles so contextual links will work

### DIFF
--- a/sass/partials/global/helpers/_accessibility.scss
+++ b/sass/partials/global/helpers/_accessibility.scss
@@ -38,10 +38,8 @@
   width: auto !important;
 }
 
-// Makes an element visually hidden by default, but visible when focused.
+// Makes an element visible when focused if it also has the visually-hidden styles.
 @mixin focusable {
-  @include visually-hidden;
-
   &:active,
   &:focus {
     @include visually-hidden-off;
@@ -49,8 +47,6 @@
 }
 
 @mixin focusable-important {
-  @include visually-hidden-important;
-
   &:active,
   &:focus {
     @include visually-hidden-off-important;

--- a/sass/partials/utilities/_accessibility.scss
+++ b/sass/partials/utilities/_accessibility.scss
@@ -8,8 +8,6 @@
 }
 
 .focusable {
-  @include visually-hidden-important;
-
   &:active,
   &:focus {
     @include visually-hidden-off-important;

--- a/templates/layout/html.html.twig
+++ b/templates/layout/html.html.twig
@@ -42,7 +42,7 @@
   </head>
   <body{{ attributes.addClass(body_classes) }}>
     <div class="skiplinks">
-      <a href="#main" class="skiplinks__link focusable">{{ 'Skip to main content'|t }}</a>
+      <a href="#main" class="skiplinks__link visually-hidden focusable">{{ 'Skip to main content'|t }}</a>
     </div>
     {{ page_top }}
     {{ page }}


### PR DESCRIPTION
This fix will allow contextual links to display, as noted in https://www.drupal.org/node/2858983