### PR TITLE
adds ability to place component sass files in pattern lab pattern folds

### DIFF
--- a/sass/partials/_components.scss
+++ b/sass/partials/_components.scss
@@ -8,3 +8,6 @@
 // from a partial in the 'components' directory. See _nav.scss for an example.
 
 @import 'sass-globbing/components';
+
+// Imports any component Sass partials in /pattern-lab/source/_patterns
+@import 'sass-globbing/components-pattern-lab';

--- a/sass/sass-globbing.json
+++ b/sass/sass-globbing.json
@@ -6,5 +6,6 @@
   "partials/sass-globbing/_module-tweaks.scss" : "partials/module-tweaks/**/*.scss",
   "partials/sass-globbing/_layout.scss": "partials/layout/**/*.scss",
   "partials/sass-globbing/_components.scss": "partials/components/**/*.scss",
+  "partials/sass-globbing/_components-pattern-lab.scss": "../pattern-lab/source/_patterns/**/*.scss",
   "partials/sass-globbing/_utilities.scss": "partials/utilities/**/*.scss"
 }

--- a/tasks/config/watch.js
+++ b/tasks/config/watch.js
@@ -2,11 +2,11 @@ module.exports = function (grunt) {
   grunt.config.merge({
     watch: {
       gesso: {
-        files: ['<%= pkg.themePath %>/sass/**/*.scss'],
+        files: ['<%= pkg.themePath %>/sass/**/*.scss','<%= pkg.themePath %>/pattern-lab/source/_patterns/**/*.scss'],
         tasks: ['gessoBuildStyles'],
       },
       patternlab: {
-        files: ['<%= pkg.themePath %>/pattern-lab/source/**/*'],
+        files: ['<%= pkg.themePath %>/pattern-lab/source/**/*.twig','<%= pkg.themePath %>/pattern-lab/source/**/*.json','<%= pkg.themePath %>/pattern-lab/source/**/*.yaml'],
         tasks: ['shell:patternlab'],
         options: {
           livereload: true


### PR DESCRIPTION
As part of the DrupalCon training, we're adding the possibility of placing component partials along-side their supporting Pattern Lab twig files.  This PR modifies the watch and compile tasks so they will also use any Sass partials placed in Pattern Lab's /source/_patterns/ folders.