### PR TITLE
Updated panels-pane.tpl.php to respect the heading element selected v…

### DIFF
--- a/templates/panels/panels-pane.tpl.php
+++ b/templates/panels/panels-pane.tpl.php
@@ -11,7 +11,7 @@
 
   <?php print render($title_prefix); ?>
   <?php if ($title): ?>
-    <h2<?php print $title_attributes; ?>><?php print $title; ?></h2>
+    <<?php print $title_heading; ?><?php print $title_attributes; ?>><?php print $title; ?></<?php print $title_heading; ?>>
   <?php endif; ?>
   <?php print render($title_suffix); ?>
 


### PR DESCRIPTION
…ia the Panelizer UI

We are hard-coding the title element in panels-pane.tpl.php as an H2, even though the Panelizer UI gives admin a choice of heading elements. Similar to the issue here: https://www.drupal.org/node/2448097