### PR TITLE
Fix contextual links

### DIFF
--- a/sass/partials/utilities/_accessibility.scss
+++ b/sass/partials/utilities/_accessibility.scss
@@ -5,12 +5,12 @@
 
 .visually-hidden {
   @include visually-hidden-important;
-}
 
-.focusable {
-  &:active,
-  &:focus {
-    @include visually-hidden-off-important;
+  &.focusable {
+    &:active,
+    &:focus {
+      @include visually-hidden-off-important;
+    }
   }
 }
 


### PR DESCRIPTION
Changing the .focusable class to only work if the element also has .visually-hidden fixes the contextual links.