### PR TITLE
added variable for pattern lab

### DIFF
--- a/_starter-kit/_data/data.yml
+++ b/_starter-kit/_data/data.yml
@@ -1,3 +1,4 @@
+pattern_lab: true
 body_class: ""
 html_class: ""
 page_title: "Page Title"


### PR DESCRIPTION
Adds a variable for Pattern Lab.  Currently not used in the Drupal version (but is in the WordPress one).  Could be used if there is code that needs to be segmented off for only Drupal or only Pattern Lab.