### PR TITLE
Configure buildkite repository mirroring.

### DIFF
--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -14,4 +14,4 @@ git config remote.drupal.url 'git@git.drupal.org:project/gesso.git'
 
 # Push the latest updates to a branch of the same name.
 # Temporary: Add the dry-run flag to prevent actually pushing changes.
-git push --dry-run drupal "$BUILDKITE_BRANCH"
+git push --dry-run drupal "$BUILDKITE_BRANCH":"$BUILDKITE_BRANCH"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -12,6 +12,9 @@ git config user.email "$GIT_EMAIL"
 # Add the remote for the drupal.org repository mirror.
 git config remote.drupal.url 'git@git.drupal.org:project/gesso.git'
 
+# Update our list of remote branches.
+git fetch --depth=5 drupal
+
 # Push the latest updates to a branch of the same name.
 # Temporary: Add the dry-run flag to prevent actually pushing changes.
-git push --dry-run drupal "$BUILDKITE_BRANCH":"$BUILDKITE_BRANCH"
+git push --dry-run drupal origin/"$BUILDKITE_BRANCH":refs/remotes/drupal/"$BUILDKITE_BRANCH"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -10,7 +10,7 @@ git config user.name "$GIT_USER"
 git config user.email "$GIT_EMAIL"
 
 # Add the remote for the drupal.org repository mirror.
-git remote add drupal 'git@git.drupal.org:project/gesso.git'
+git config remote.drupal.url 'git@git.drupal.org:project/gesso.git'
 
 # Push the latest updates to a branch of the same name.
 # Temporary: Add the dry-run flag to prevent actually pushing changes.

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -12,5 +12,4 @@ git config remote.drupal.url 'git@git.drupal.org:project/gesso.git'
 git fetch --depth=5 drupal
 
 # Push the latest updates to a branch of the same name.
-# Temporary: Add the dry-run flag to prevent actually pushing changes.
-git push --dry-run drupal origin/"$BUILDKITE_BRANCH":refs/remotes/drupal/"$BUILDKITE_BRANCH"
+git push drupal origin/"$BUILDKITE_BRANCH":refs/remotes/drupal/"$BUILDKITE_BRANCH"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+# Ensure a host verification prompt doesn't prevent the connection.
+ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
+
+# Assign the expected committer details.
+git config user.name "$GIT_USER"
+git config user.email "$GIT_EMAIL"
+
+# Add the remote for the drupal.org repository mirror.
+git remote add drupal 'git@git.drupal.org:project/gesso.git'
+
+# Push the latest updates to a branch of the same name.
+# Temporary: Add the dry-run flag to prevent actually pushing changes.
+git push --dry-run drupal "$BUILDKITE_BRANCH"

--- a/.buildkite/build.sh
+++ b/.buildkite/build.sh
@@ -5,10 +5,6 @@ set -exuo pipefail
 # Ensure a host verification prompt doesn't prevent the connection.
 ssh-keyscan git.drupal.org >> ~/.ssh/known_hosts
 
-# Assign the expected committer details.
-git config user.name "$GIT_USER"
-git config user.email "$GIT_EMAIL"
-
 # Add the remote for the drupal.org repository mirror.
 git config remote.drupal.url 'git@git.drupal.org:project/gesso.git'
 


### PR DESCRIPTION
Add scripts for buildkite automation of mirroring between repos during branch commits.

For examples of a successful build (using a dry-run flag to avoid actual pushes) see [this job](https://buildkite.com/forum-one/gesso/builds/14#53daf5fa-ff10-4fe1-95d9-79f42b0f1dca).