### PR TITLE
Support multiple ways of specifying text color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ css/*.css
 css/*.map
 dependencyGraph.json
 .vscode
+.idea

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -36,19 +36,25 @@ const paletteTransformer = (node, doc, map) => {
 
 /** @type {import('./types').ScalarTransformer} */
 const colorTransformer = (node, doc, map) => {
+  // If the value is a quoted string, don't try to look it up anywhere.
+  if (node.type === 'QUOTE_DOUBLE' ||
+      node.type === 'QUOTE_SINGLE') {
+    return identityTransformer(node);
+  }
+
   const key = String(node.value);
   const keys = ['gesso', 'colors', ...key.split('.')];
 
+  // Start by checking if the value is a reference to gesso.colors.
   // @ts-ignore
   const value = doc.getIn(keys, /* keep node */ true);
-  if (value === undefined) {
-    throw map.errorForRange(
-      `Could not resolve '${key}' in gesso.colors`,
-      node.range,
-    );
+  if (value !== undefined) {
+    return paletteTransformer(value, doc, map);
   }
-
-  return paletteTransformer(value, doc, map);
+  // If it's not, we have two possibilities: 1) it's actually a palette color.
+  // 2) It's an invalid key. Since the paletteTransformer can handle either,
+  // just kick it over there and let it throw any errors.
+  return paletteTransformer(node, doc, map);
 };
 
 /** @type {import('./types').ScalarTransformer} */


### PR DESCRIPTION
Resolves #232 .

Within the gesso.typography section of the config file, the color property can be one of three types of values:

1. A gesso.colors key (i.e. `text.primary`)
2. A gesso.palette key (i.e. `brand.blue.base`).
3. A single or double-quoted string (i.e. `'inherit'`). 'inherit' was the main use case I was thinking of here, but you could also use it to specify some kind of one-off override color, should you have an edge case where that was necessary. If you want the value to be used as-is, it _must_ be surrounded in quotes. Otherwise you'll just get an error that the key could not be resolved.