### PR TITLE
Allow raw Sass code in design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,133 +97,146 @@ gulp build
 
 To access the Pattern Lab instance, append `/pattern-lab/index.html` to your site URL and theme directory (e.g. http://localhost:8080/themes/gesso/pattern-lab/index.html) or, if developing locally, just open that index.html file directly in the browser from your file system.
 
-
 ### Design Tokens
-Gesso uses a configuration file 'source/_patterns/00-config/config.design-tokens.yml' to manage the theme's design tokens and automatically generate the global sass map for styling and patterns to represent the theme's design tokens. The default gulp command will monitor changes in the config and rebuild all neccessary assets. To rebuild the theme assets a single time run `gulp gessoBuild`
+
+Gesso uses a configuration file 'source/\_patterns/00-config/config.design-tokens.yml' to manage the theme's design tokens and automatically generate the global sass map for styling and patterns to represent the theme's design tokens. The default gulp command will monitor changes in the config and rebuild all neccessary assets. To rebuild the theme assets a single time run `gulp gessoBuild`
+
+#### Design Token Colors
+
+In addition to using hex values for colors, you can also use Sass functions and
+provide a fallback hex value to be used in Pattern Lab. This is useful when
+pulling in an external design system, such as [USWDS](https://designsystem.digital.gov/).
+
+For example:
+
+```
+gesso:
+  palette:
+    brand:
+      blue:
+        base: '#0071bc'
+        light: !sass
+          sass: 'lighten(#0071bc, 20%)'
+          fallback: '#23a7ff'
+```
 
 #### Design Token Functions
-The following Sass functions can be used to access the tokens defined in `config.design-tokens.yml`.
 
+The following Sass functions can be used to access the tokens defined in `config.design-tokens.yml`.
 
 **`gesso-box-shadow($shadow)` Output a shadow value from the box-shadow token list**
 
 example:
+
 ```
 box-shadow: gesso-box-shadow(1);
 ```
 
-
 **`gesso-breakpoint($breakpoint)` Output a size value from the breakpoints token list**
 
 example:
+
 ```
 @include breakpoint(gesso-breakpoint(lg)) {
   display: flex;
 }
 ```
 
-
 **`gesso-brand($color, $variant)` Output a color value from the palette brand token list**
 
 example:
+
 ```
 color: gesso-brand(blue, light);
 ```
 
-
 **`gesso-color($type, $subtype)` Output a color value from the colors token list**
 
 example:
+
 ```
 color: gesso-color(text, primary);
 ```
 
-
 **`gesso-constrain($constrain)` Output a size value from the constrains token list**
 
 example:
+
 ```
 max-width: gesso-constrain(sm);
 ```
 
-
 **`gesso-duration($duration)` Output a timing value from the transitions duration token list**
 
 example:
+
 ```
 transition-duration: gesso-duration(short);
 ```
 
-
 **`gesso-easing($easing)` Output an easing value from the transitions ease token list**
 
 example:
+
 ```
 transition-timing-function: gesso-easing(ease-in-out);
 ```
 
-
 **`gesso-font-family($family)` Output a stack value from the font-family token list**
 
 example:
+
 ```
 font-family: gesso-font-family(primary);
 ```
 
-
 **`gesso-font-size($size)` Output a size value from the font-size token list**
 
 example (combined with the rem() function to convert to rems):
+
 ```
 font-size: rem(gesso-font-size(2));
 ```
 
-
 **`gesso-font-weight($weight)` Output a weight value from the font-weight token list**
 
 example:
+
 ```
 font-weight: gesso-font-weight(semibold);
 ```
 
-
 **`gesso-grayscale($color)` Output a color value from the palette grayscale token list**
 
 example:
+
 ```
 color: gesso-grayscale(gray-2);
 ```
 
-
 **`gesso-line-height($height)` Output a height value from the line-height token list**
 
 example:
+
 ```
 line-height: gesso-line-height(tight);
 ```
 
-
 **`gesso-spacing($spacing)` Output a size value from the spacing token list**
 
 example (combined with the rem() function to convert to rems):
+
 ```
 margin-bottom: rem(gesso-spacing(md));
 ```
 
-
 **`gesso-z-index($index)` Output an index value from the z-index token list**
 
 example:
+
 ```
 z-index: gesso-z-index(modal);
 ```
-
-
-
-
-
-
-
 
 ### Creating New Components
 
@@ -237,8 +250,8 @@ npm run component
 ### Build Artifacts
 
 By default, the compiled Pattern Lab and Sass files (e.g., /pattern-lab/
-and /css/*.css) as well as some configuration artifacts (e.g., design-tokens.artifact.yml,
-_design-tokens.artifact.scss) are ignored by Git as these files are generated when
+and /css/\*.css) as well as some configuration artifacts (e.g., design-tokens.artifact.yml,
+\_design-tokens.artifact.scss) are ignored by Git as these files are generated when
 the Gulp tasks run. To change this, edit the included .gitignore file.
 
 ### Sass/Gulp dependencies

--- a/lib/SassValue.js
+++ b/lib/SassValue.js
@@ -1,0 +1,66 @@
+// @ts-check
+
+const { createNode } = require('yaml');
+const { parseMap, stringifyString } = require('yaml/util');
+
+/**
+ * Class to represent a raw Sass value. This class acts as a signifier that the token
+ * lookup process should be bypassed. The internal representation uses two slots:
+ * 1. `sass`, which is a raw Sass string.
+ * 2. `fallback`, an optional fallback token. This is only needed when generating output
+ *    in a non-Sass environment (e.g., Pattern Lab swatches).
+ *
+ * A value of this class can be constructed in the design tokens file by using the `!sass`
+ * tag. There are two accepted syntaxes:
+ * 1. Single-value shorthand. This is used primarily for lookups when the developer knows
+ *    that no design token will be needed in, e.g., Pattern Lab.
+ *
+ *    ```yaml
+ *    foo: !sass some-function(foo,bar)
+ *    ```
+ *
+ * 2. Object notation. This uses a map with `sass` and `fallback` keys. The `sass` key is
+ *    injected raw into the stylesheet code, and `fallback` is used as mentioned above.
+ *
+ *    ```yaml
+ *    foo: !sass
+ *      sass: some-function(foo,bar)
+ *      fallback: '#f00'
+ *    ```
+ */
+class SassValue {
+  /**
+   * @param sass The raw Sass string to inject.
+   * @param [fallback] The fallback value to output for other environments.
+   */
+  constructor(sass, fallback) {
+    this.sass = sass;
+    this.fallback = fallback;
+  }
+}
+
+// YAML custom tag for the SassValue class (cf. https://eemeli.org/yaml/#custom-data-types)
+// Do NOT use this tag on output; Pattern Lab uses YAML.safeLoad() which throws exceptions
+// when it encounters unknown tags. We instead rely on the fact that the yaml package
+// serializes class instances as YAML maps - this gives us the ['sass' => ..., 'fallback' => ...]
+// structure we need in Twig.
+const tag = {
+  identify: value => value instanceof SassValue,
+  tag: '!sass',
+  resolve(doc, cst) {
+    // This is a two-value YAML document: { sass, fallback } - deserialize into a full
+    // SassValue instance.
+    if (cst.type === 'MAP') {
+      const map = parseMap(doc, cst);
+      return new SassValue(map.get('sass'), map.get('fallback'));
+    }
+
+    // We assume this is a scalar - this means that if you say !sass [foo], the results
+    // won't quite be what you expect.
+    return new SassValue(cst.strValue);
+  },
+};
+
+SassValue.tag = tag;
+
+module.exports = SassValue;

--- a/lib/readSource.js
+++ b/lib/readSource.js
@@ -10,6 +10,7 @@ const YAML = require('yaml');
 const readFile = util.promisify(fs.readFile);
 
 const CodeMap = require('./CodeMap');
+const SassValue = require('./SassValue');
 
 /**
  * @param {string} sourcePath
@@ -19,7 +20,7 @@ async function readSource(sourcePath) {
   const source = await readFile(sourcePath, 'utf-8');
   const map = new CodeMap(source);
 
-  const ast = YAML.parseDocument(source);
+  const ast = YAML.parseDocument(source, { customTags: [SassValue.tag] });
   if (ast.errors && ast.errors.length) {
     const max = Math.min(ast.errors.length, 10);
     const errors = ast.errors.slice(0, max).map(yamlError => {

--- a/lib/renderSass.js
+++ b/lib/renderSass.js
@@ -4,6 +4,8 @@
 
 const { NaniError } = require('nani');
 
+const SassValue = require('./SassValue');
+
 /**
  * Prepares a JS value for output as a Sass value.
  *
@@ -42,6 +44,9 @@ function createSassMap(data, indent = 2) {
       default:
         if (value === null || value === undefined) {
           output += 'null';
+        } else if (value instanceof SassValue) {
+          // Don't output the `fallback' field for raw Sass.
+          output += value.sass;
         } else {
           output += createSassMap(value, indent + 2);
         }

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -2,24 +2,36 @@
 
 const { NaniError, fromArray } = require('nani');
 
+const SassValue = require('./SassValue');
+
 /**
  * @param {import('yaml').ast.AstNode} node
  * @return {node is import('yaml').ast.ScalarNode}
  */
 function isScalar(node) {
-  const type = node.type;
+  const { tag, type } = node;
+
   return (
     type === 'BLOCK_FOLDED' ||
     type === 'BLOCK_LITERAL' ||
     type === 'PLAIN' ||
     type === 'QUOTE_DOUBLE' ||
-    type === 'QUOTE_SINGLE'
+    type === 'QUOTE_SINGLE' ||
+    // If we have a tagged sass value, always consider it a scalar
+    // (even if it's a structured object with a 'fallback' field)
+    tag === '!sass'
   );
 }
 
 /** @type {import('./types').ScalarTransformer} */
 const paletteTransformer = (node, doc, map) => {
-  const key = String(node.value);
+  // Bypass key lookups for SassValue objects
+  const nodeValue = node.value;
+  if (nodeValue instanceof SassValue) {
+    return nodeValue;
+  }
+
+  const key = String(nodeValue);
   const keys = ['gesso', 'palette', ...key.split('.')];
 
   // @ts-ignore
@@ -37,12 +49,16 @@ const paletteTransformer = (node, doc, map) => {
 /** @type {import('./types').ScalarTransformer} */
 const colorTransformer = (node, doc, map) => {
   // If the value is a quoted string, don't try to look it up anywhere.
-  if (node.type === 'QUOTE_DOUBLE' ||
-      node.type === 'QUOTE_SINGLE') {
+  if (node.type === 'QUOTE_DOUBLE' || node.type === 'QUOTE_SINGLE') {
     return identityTransformer(node);
   }
 
-  const key = String(node.value);
+  const nodeValue = node.value;
+  if (nodeValue instanceof SassValue) {
+    return nodeValue;
+  }
+
+  const key = String(nodeValue);
   const keys = ['gesso', 'colors', ...key.split('.')];
 
   // Start by checking if the value is a reference to gesso.colors.
@@ -59,7 +75,12 @@ const colorTransformer = (node, doc, map) => {
 
 /** @type {import('./types').ScalarTransformer} */
 const fontFamilyTransformer = (node, doc, map) => {
-  const key = String(node.value);
+  const nodeValue = node.value;
+  if (nodeValue instanceof SassValue) {
+    return nodeValue;
+  }
+
+  const key = String(nodeValue);
   const keys = ['gesso', 'typography', 'font-family', ...key.split('.')];
 
   // @ts-ignore
@@ -118,7 +139,12 @@ function getScalarVisitor(path) {
     }
 
     return (node, doc, map) => {
-      const key = node.value;
+      const nodeValue = node.value;
+      if (nodeValue instanceof SassValue) {
+        return nodeValue;
+      }
+
+      const key = nodeValue;
       const keys = ['gesso', 'typography', prefix];
 
       // First, attempt a lookup of the typography at gesso.typography - this'll weed

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,6 +1,7 @@
 import * as YAML from 'yaml';
 
 type CodeMap = import('./CodeMap');
+type SassValue = import('./SassValue');
 
 export interface ParsedSource {
   readonly path: string;
@@ -25,4 +26,4 @@ export type ScalarTransformer = (
   node: YAML.ast.ScalarNode,
   doc: YAML.ast.Document,
   map: CodeMap,
-) => string | number | boolean;
+) => string | number | boolean | SassValue;

--- a/source/_patterns/01-global/00-colors/_color-item.twig
+++ b/source/_patterns/01-global/00-colors/_color-item.twig
@@ -1,9 +1,22 @@
-{% set style = 'background-color:' ~ color  ~ ';' %}
+{% if color is iterable %}
+  {% set color_label = color['sass'] %}
+  {% set color_value = color['fallback'] is empty ? color['sass'] : color['fallback'] %}
+{% else %}
+  {% set color_label = color %}
+  {% set color_value = color %}
+{% endif %}
+{% set style = 'background-color:' ~ color_value  ~ ';' %}
 
 <div class="pattern-lab-color-swatch">
   <div class="pattern-lab-color-swatch__indicator" style="{{ style }}"></div>
   <div class="pattern-lab-color-swatch__meta">
     <div class="pattern-lab-color-swatch__name">{{ name }}</div>
-    <div class="pattern-lab-color-swatch__hex">{{ color }}</div>
+    <div class="pattern-lab-color-swatch__hex">
+      {% if color_value is sameas(color_label) %}
+        {{ color_value }}
+      {% else %}
+        {{ color_value }}<br />(<code>{{ color_label }}</code>)
+      {% endif %}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
# Discussion

To better integrate with other design systems, Gesso should have the ability to defer to another system's tokens. As an example, [the USWDS](https://designsystem.digital.gov/) uses `color('<name>')` to access its color tokens. In order to avoid duplication of work, it's better to treat that function call as the authoritative value than to copy and paste it and diverge from the upstream source of truth.

This PR achieves that goal by introducing a custom YAML tag that can be used in `config.design-tokens.yml`. This tag is `!sass`, and indicates to the processor that this value is Sass code to be injected directly and should bypass the normal behavior - this includes token lookup. This means that we can define tokens in terms of other systems' tokens, as well as use lookups when we need to switch sources of truth — that is, we can define a brand blue as coming from another system, or indicate that the primary text color is from another system (see examples below). The code that outputs the `$gesso` Sass map knows to inject the raw Sass directly. This is how we stay in sync with the upstream tokens: when compiled, the Sass code will always use the code instead of a hard-coded value.

# Input Syntax

There are two input syntaxes for this tag: fallback notation and shorthand.

The fallback syntax is a tagged YAML object with `sass` and `fallback` fields. The suggested syntax is to use the block literals, to make it easier to see when the normal token system is being bypassed:

```yaml
example:
  red: !sass
    sass: 'mix(#fff, #f00, 0.5)'
    fallback: '#f00'
```

The second syntax is shorthand notation. This notation is used when there's no need for a separately-labeled fallback. It looks like this:

```yaml
example:
  blue: !sass 'mix(#fff, #00f, 0.5)'
```

This syntax is primarily encouraged for use in token lookups (e.g., `!sass color('red-40')` instead of `red.light`, since the absence of a fallback limits its use as a brand token.

# Output

For the rest of this section, we'll assume these hypothetical tokens:

```yaml
gesso:
  palette:
    brand:
      blue:
        base: !sass mix(#fff,#00f,0.5)
        light: !sass
          sass: mix(#fff,#00f,0.25)
          fallback: '#00f'
```

When this code outputs Sass, the fallback is ignored in both the fallback and shorthand notation:

```sass
$gesso: (
  palette: (
    brand: (
      blue: (
        base: mix(#fff,#00f,0.5),
        light: mix(#fff,#00f,0.25),
        // [snip]
```

However, the code generates an object with `sass` and `fallback` values in both cases. Templates (such as Pattern Lab swatches) that expect simple tokens can check for `token is iterable` in Twig and read the array values. Notice that the shorthand syntax still output an array - this way, the template code always knows when the normal tokens were bypassed and can indicate to anyone reviewing PL that the source of truth for the token isn't stored directly in the design tokens file.

```yaml
gesso:
  palette:
    brand:
      blue:
        base:
          &a1
          sass: mix(#fff,#00f,0.5)
          fallback: null
        light:
          &a2
          sass: mix(#fff,#00f,0.25)
          fallback: "#00f"
```

(Aside: for some reason, the YAML library likes to output anchors for these values. I don't know why, and it's very annoying. However, it doesn't break the Pattern Lab build, so I'm going to ignore it for now.)

# Example: Swatches

In addition to the above code changes, I modified `_color-item.twig` to demonstrate this behavior. Using the example above, the swatches generated for blue.base and blue.light are below. Note that the base color appears broken because there's no fallback - the generated css is `background-color: mix(#fff, #00f, 0.5)`, which doesn't work in Firefox. The second swatch, since it has a fallback, is able to display an approximation of the compiled Sass value (and we can see it when the token is referenced via `gesso-color()` or `gesso-brand()`).

![image](https://user-images.githubusercontent.com/194893/66218156-9de4a100-e696-11e9-9a74-69b1ccfbecdf.png)

When used as token lookup, the rendered Sass is used directly. The default Gesso text links use `brand.blue.base`, and we can see that the compiled styles correctly use the value of `mix(#fff, #00f, 0.5)` (`#0101ff`, according to SassMeister):

```css
a {
  background-color: transparent;
  color: #0101ff;
  outline-offset: 0.125em;
  /* [snip] */
```