### PR TITLE
8.x 3.x test search box mobile

### DIFF
--- a/js/src/modules/_MobileMenu.es6.js
+++ b/js/src/modules/_MobileMenu.es6.js
@@ -294,12 +294,18 @@ class _MobileMenu {
     this.close();
 
     let resizeTimeout = false;
+    let lastWindowWidth = window.innerWidth;
     window.addEventListener('resize', () => {
-      if (resizeTimeout !== false) {
-        clearTimeout(resizeTimeout);
-      }
+      const currWindowWidth = window.innerWidth;
 
-      resizeTimeout = setTimeout(this._toggleMenuDisplay, 200);
+      if (lastWindowWidth !== currWindowWidth) {
+        if (resizeTimeout !== false) {
+          clearTimeout(resizeTimeout);
+        }
+
+        resizeTimeout = setTimeout(this._toggleMenuDisplay, 200);
+        lastWindowWidth = currWindowWidth;
+      }
     });
   }
 

--- a/js/src/modules/_MobileMenu.es6.js
+++ b/js/src/modules/_MobileMenu.es6.js
@@ -314,7 +314,10 @@ class _MobileMenu {
     this._setTabIndex(links, 0);
 
     document.body.classList.add('has-open-mobile-menu');
-    this.overlay.setAttribute('style', 'display: block;');
+    this.overlay.setAttribute(
+      'style',
+      `display: block; height: ${window.innerHeight}px`
+    );
 
     this.toggleButton.setAttribute('aria-expanded', 'true');
 

--- a/js/src/modules/_MobileMenu.es6.js
+++ b/js/src/modules/_MobileMenu.es6.js
@@ -4,7 +4,7 @@ class _MobileMenu {
   constructor({
     toggleSubNav = true, // Enable subnav toggle
     navMenu = '.menu--main', // Selector for primary menu to clone for mobile menu
-    searchBlock = '', // Selector for search block
+    searchBlock = '.js-search-block', // Selector for search block
     utilityMenu = '', // Selector for utility menu to add to mobile menu
     header = '.l-header', // Selector for site header
     toggleButton = '.mobile-menu-button--menu', // Selector for Menu toggle

--- a/source/_patterns/02-base/02-html-elements/02-body/_body.scss
+++ b/source/_patterns/02-base/02-html-elements/02-body/_body.scss
@@ -7,4 +7,12 @@ body {
   margin: 0;
   padding: 0;
   word-wrap: break-word;
+
+  // stylelint-disable selector-no-qualifying-type
+  &.has-open-mobile-menu  {
+    overflow: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+  // stylelint-enable
 }
+

--- a/source/_patterns/04-components/mobile-menu/_mobile-menu.scss
+++ b/source/_patterns/04-components/mobile-menu/_mobile-menu.scss
@@ -18,7 +18,6 @@ $mobile-menu-line-height: gesso-line-height(base);
   background-color: $mobile-menu-fallback-bg-color;
   background-color: $mobile-menu-bg-color;
   left: 0;
-  min-height: 100vh;
   overflow-y: auto;
   position: fixed;
   top: 0;

--- a/source/_patterns/06-pages/_page-default.twig
+++ b/source/_patterns/06-pages/_page-default.twig
@@ -44,6 +44,13 @@
       {% endblock %}
     {% endembed %}
 
+    <div class="js-search-block">
+      <div class="form-item form-item--search">
+        <label class="form-item__label" for="edit-search">Search</label>
+        <input class="form-item__search" id="edit-search" type="search" size="60" maxlength="128">
+      </div>
+    </div>
+
     {% embed '@layouts/breadcrumb/breadcrumb.twig' with {
       'has_constrain': false
     } %}


### PR DESCRIPTION
@dcmouyard 
I added a check in the resize handler to verify that screen width actually changed. The input and scroll issues appear resolved in browserstack on ios and android devices and  Apparently in mobile browsers using the text input or overscrolling triggers height/resize events.  There's an over-scroll issue in the ios safari(browserstack) where you can see the content underneath the menu if you over-scroll. But was unable to replicate on the actual device. I would also recommend that we put the search bar at the top as android/google device can sometimes overlay the keyboard versus triggering a resize.