### PR TITLE
Add Dockerfile for container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.DS_Store
+node_modules
+.sass-cache
+pattern-lab
+source/_data/design-tokens.artifact.yml
+source/_patterns/00-config/_design-tokens.artifact.scss
+css/*.css
+css/*.map
+js/dist/*.js
+js/dist/*.map
+dependencyGraph.json
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM php:7.3-cli
+
+ENV NODE_VERSION=v12.13.0 \
+  NODE_CHECKSUM=c69671c89d0faa47b64bd5f37079e4480852857a9a9366ee86cdd8bc9670074a
+
+ENV NODE_FILENAME=node-${NODE_VERSION}-linux-x64.tar.gz
+
+RUN set -ex \
+  && cd /tmp \
+  && curl -fsSO "https://nodejs.org/dist/${NODE_VERSION}/${NODE_FILENAME}" \
+  && echo "${NODE_CHECKSUM}  ${NODE_FILENAME}" | sha256sum -c \
+  && tar xf "${NODE_FILENAME}" --strip-components=1 -C /usr/local \
+  && rm "${NODE_FILENAME}" \
+  && npm i -g gulp-cli
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN if test -e package-lock.json; then npm ci; else npm i; fi
+
+COPY . .


### PR DESCRIPTION
This adds a Dockerfile to Gesso. This file adds node.js to a PHP CLI image, allowing for Pattern Lab and Gulp to run in the same container.

The `.dockerignore` has been greatly simplified from previous versions; this will allow using the Gesso image built from sources to be used in production scenarios as well as local development.
