### PR TITLE
Consolidate and add to unit conversion functions

### DIFF
--- a/source/_patterns/00-config/00-functions/_functions.em.scss
+++ b/source/_patterns/00-config/00-functions/_functions.em.scss
@@ -1,7 +1,0 @@
-// @file
-// Em conversion
-
-// Convert pixel values to em.
-@function em($px, $base: gesso-get-map(typography, base-font-size)) {
-  @return ($px / $base) * 1em;
-}

--- a/source/_patterns/00-config/00-functions/_functions.rem.scss
+++ b/source/_patterns/00-config/00-functions/_functions.rem.scss
@@ -1,7 +1,0 @@
-// @file
-// Rem conversion
-
-// Convert pixel values to rem.
-@function rem($px, $base: gesso-get-map(typography, base-font-size)) {
-  @return ($px / $base) * 1rem;
-}

--- a/source/_patterns/00-config/00-functions/_functions.unit-convert.scss
+++ b/source/_patterns/00-config/00-functions/_functions.unit-convert.scss
@@ -14,3 +14,59 @@
     @return $value;
   }
 }
+
+/// Convert values to px.
+// @param {Number} $value - Value to convert. Can be px, em, or rem.
+//   If unitless, pixels are assumed.
+// @param {Number} $base - Base font size in pixels.
+// @return {Number} - Value in pixels.
+
+@function px($value, $base: gesso-get-map(typography, base-font-size)) {
+  @if unitless($value) {
+    @return convert($value, px);
+  }
+  @if (type-of($base) != 'number' or unit($base) != 'px') {
+    @error "Base font size must be in pixels.";
+  }
+  @return strip-unit($value) * $base;
+}
+
+/// Convert values to em.
+// @param {Number} $value - Value to convert. Can be px, em, or rem.
+//   If unitless, pixels are assumed.
+// @param {Number} $base - Base font size in pixels.
+// @return {Number} - Value in ems.
+
+@function em($value, $base: gesso-get-map(typography, base-font-size)) {
+  @if (type-of($base) != 'number' or unit($base) != 'px') {
+    @error "Base font size must be in pixels.";
+  }
+  @if (type-of($value) == 'number' and unit($value) != 'em') {
+    @if (unit($value) != 'px') {
+      $value: px($value, $base);
+    }
+    @return ($value / $base) * 1em;
+  }
+  @return $value;
+}
+
+/// Convert values to rem.
+// @param {Number} $value - Value to convert. Can be px, em, or rem.
+//   If unitless, pixels are assumed. If ems, size will be converted using
+//   the same base (so 0.5em is equal to 0.5rem). If you want to convert using
+//   a different font size, do rem(px($emValue, $emBase), $remBase).
+// @param {Number} $base - Base font size in pixels.
+// @return {Number} - Value in rems.
+
+@function rem($value, $base: gesso-get-map(typography, base-font-size)) {
+  @if (type-of($base) != 'number' or unit($base) != 'px') {
+    @error "Base font size must be in pixels.";
+  }
+  @if (type-of($value) == 'number' and unit($value) != 'rem') {
+    @if (unit($value) != 'px') {
+      $value: px($value, $base);
+    }
+    @return ($value / $base) * 1rem;
+  }
+  @return $value;
+}


### PR DESCRIPTION
This came out of the work on gesso-uswds, as many of the USWDS design system tokens are in units other than pixels (usually rems). Depending on the current design token settings, a call to `rem(gesso-spacing(xs))` might pass a pixel value to the function or might pass a rem value. (Or, since users can presumably put any valid size in the design token YAML file, this could also be an em value.)

The following will now work:
```
$base-font-size: 16px; // Base font size MUST be in pixels or the functions will throw an error.
rem(16px, $base-font-size); // 1rem
rem(1em, $base-font-size); // 1em
rem(px(1em, 12px), $base-font-size); // 0.75rem
rem(1rem, $base-font-size); // 1rem
rem(16, $base-font-size); // 1rem. Unitless values are assumed to be pixels.
```
Same for the em() function. (As before, the second parameter is optional and will default to the Gesso font base size if not specified.)

As noted in the comments on the Sass file, em to rem conversion is imperfect, since the em base size might be different than the rem base size. If that's the case, you're better off following the third example above, where you convert the em to pixels and the resulting size to rems.

Unitless handling is in there as a convenience because some other px-to-rem conversion functions I've seem (namely Foundation's `rem-calc()`, which I used to use a bunch) use unitless values. I'd still recommend we explicitly specify the unit when setting any values within Gesso itself.