### PR TITLE
Add create_attribute function for Pattern Lab

### DIFF
--- a/pattern-lab-config.json
+++ b/pattern-lab-config.json
@@ -239,6 +239,10 @@
         {
           "file": "source/_twig-components/functions/url.function.php",
           "functions": ["addUrlFunction"]
+        },
+        {
+          "file": "source/_twig-components/functions/create_attribute.function.php",
+          "functions": ["addCreateAttributeFunction"]
         }
       ]
     }

--- a/source/_twig-components/functions/create_attribute.function.php
+++ b/source/_twig-components/functions/create_attribute.function.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @file
+ * Add "create_attribute" function for Pattern Lab.
+ */
+
+function addCreateAttributeFunction(\Twig_Environment &$env, $config) {
+  $function = new Twig_SimpleFunction(
+    'create_attribute',
+    function ($attributes = []) {
+      foreach ($attributes as $key => $value) {
+        if (!is_array($value)) {
+          $value = array($value);
+        }
+        print ' ' . $key . '="' . join(' ', $value) . '"';
+      }
+    },
+    array('is_safe' => array('html'))
+  );
+  $env->addFunction($function);
+}


### PR DESCRIPTION
Pulls in a `create_attribute` function so it can be used in PL templates. The PL version isn't exactly equivalent to the Drupal version (you can't chain functions), but lets you do something like this in your PL template:

```
{% set link_attributes = link_attributes|merge({
  "class": link_attributes["class"]|merge([
    'usa-accordion__button',
    'usa-nav__link'
  ]),
  "aria-expanded": "false"
}) %}
<button {{ create_attribute(link_attributes) }}><span>{{ item.title }}</span></button>
```
