### PR TITLE
Allow for additional custom menu classes

### DIFF
--- a/source/_patterns/04-components/menu/menu--main/menu--main.yml
+++ b/source/_patterns/04-components/menu/menu--main/menu--main.yml
@@ -227,3 +227,10 @@ items:
             attributes:
               class: ''
         in_active_trail: false
+menu_class:
+  - 'primary-nav'
+item_class:
+  - 'primary-nav__item'
+link_class:
+  - 'primary-nav__link'
+  - 'special-link-class'

--- a/source/_patterns/04-components/menu/menu.twig
+++ b/source/_patterns/04-components/menu/menu.twig
@@ -1,17 +1,21 @@
 {% import _self as menus %}
 
-{{ menus.menu_links(items, attributes, 0, menu_name) }}
+{{ menus.menu_links(items, attributes, 0, menu_name, menu_class, item_class, link_class) }}
 
-{% macro menu_links(items, attributes, menu_level, menu_name) %}
+{% macro menu_links(items, attributes, menu_level, menu_name, menu_class, item_class, link_class) %}
   {% import _self as menus %}
   {% if items %}
     {% if menu_level == 0 %}
       {# double quotes around class using menu_name needed for interpolation #}
+      {% set additional_classes = [
+        'menu',
+        "menu--#{menu_name}"
+      ] %}
+      {% if menu_class %}
+        {% set additional_classes = additional_classes|merge(menu_class) %}
+      {% endif %}
       {% set additional_attributes = {
-        'class': [
-          'menu',
-          "menu--#{menu_name}",
-        ]
+        'class': additional_classes
       } %}
       <ul {{ add_attributes(additional_attributes) }}>
     {% else %}
@@ -40,6 +44,12 @@
       {% endif %}
       {% if item['original_link'].options.attributes.class %}
         {% set link_classes = link_classes|merge([item['original_link'].options.attributes.class]) %}
+      {% endif %}
+      {% if item_class %}
+        {% set item_classes = item_classes|merge(item_class) %}
+      {% endif %}
+      {% if link_class %}
+        {% set link_classes = link_classes|merge(link_class) %}
       {% endif %}
 
       {% set additional_item_attributes = {


### PR DESCRIPTION
Another change from gesso-uswds that seems like it could be broadly useful. Allows someone to set one or more additional classes on the menu, menu list item, and/or menu link. Could be used for integration with an external design system that requires specific classes (e.g. USWDS) or simply to reuse some existing pattern on the site.

Example Usage:
```
{% include '@components/menu/menu.twig' with {
  'menu_name': 'account',
  'items': items,
  'menu_class': ['usa-nav__secondary-links'],
  'item_class': ['usa-nav__secondary-item']
} %}
```

Output:
```
<ul class="menu menu--account usa-nav__secondary-links">
  <li class="menu__item usa-nav__secondary-item"><a href="#" class="menu__link">Item</a></li>
  <li class="menu__item usa-nav__secondary-item"><a href="#" class="menu__link">Item</a></li>
</ul>
```