### PR TITLE
Remove unwanted focus styling on form items in Firefox

### DIFF
--- a/source/_patterns/04-components/form-item/form-item--range/_form-item--range.scss
+++ b/source/_patterns/04-components/form-item/form-item--range/_form-item--range.scss
@@ -43,6 +43,11 @@ $form-range-track-height: 10px !default;
     margin: 0.2em 0;
     padding: 0;
 
+    // Remove outer focus styling on Firefox.
+    &::-moz-focus-outer {
+      border: 0;
+    }
+
     &:focus {
       box-shadow: none;
       outline: 0;

--- a/source/_patterns/04-components/form-item/form-item--select/_form-item--select.scss
+++ b/source/_patterns/04-components/form-item/form-item--select/_form-item--select.scss
@@ -19,6 +19,12 @@ $form-select-arrow-size: 20px !default;
       }
     }
 
+    // Remove inner focus styling on Firefox.
+    &:-moz-focusring {
+      color: transparent;
+      text-shadow: 0 0 0 #000;
+    }
+
     &::-ms-expand {
       display: none;
     }


### PR DESCRIPTION
This PR removes the default Firefox focus styling of select and range form elements.