### PR TITLE
Add underlines to heading links

### DIFF
--- a/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
+++ b/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
@@ -83,10 +83,6 @@ h3,
 h4,
 h5,
 h6 {
-  a {
-    text-decoration: none;
-  }
-
   // Remove top margin for adjacent subheadings.
   & + & {
     margin-top: 0;


### PR DESCRIPTION
For accessibility, all links should have underlines by default unless there are other design treatments that make it obvious they’re links.