### PR TITLE
Add focus mixin with updated default focus styles

### DIFF
--- a/source/_patterns/00-config/01-mixins/_mixins.button.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.button.scss
@@ -59,7 +59,6 @@ $button-font-size: gesso-base-font-size() !default;
   &:focus {
     background-color: $color-background-hover;
     color: $color-text-hover;
-    outline: 0;
   }
 
   &:active {

--- a/source/_patterns/00-config/01-mixins/_mixins.focus.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.focus.scss
@@ -1,0 +1,11 @@
+// @file
+// Focus mixin
+
+@mixin focus($color: gesso-color(ui, generic, focus), $width: 2px, $offset: 2px) {
+  outline: $width solid transparent;
+  outline-offset: $offset;
+
+  &:focus {
+    outline-color: $color;
+  }
+}

--- a/source/_patterns/00-config/config.design-tokens.yml
+++ b/source/_patterns/00-config/config.design-tokens.yml
@@ -130,6 +130,7 @@ gesso:
         accent: brand.blue.base
         accent-dark: brand.blue.dark-1
         accent-light: brand.blue.light
+        focus: brand.blue.light
       error:
         background: other.red.light-1
         border: other.red.light

--- a/source/_patterns/02-base/02-html-elements/15-inline-elements/_inline-elements.scss
+++ b/source/_patterns/02-base/02-html-elements/15-inline-elements/_inline-elements.scss
@@ -2,16 +2,13 @@
 // Inline element styles.
 
 a {
+  @include focus();
   background-color: transparent;
   color: gesso-color(text, link);
-  outline-offset: em(2px); // Improves readability when focused.
   -webkit-text-decoration-skip: objects;
-  transition: color gesso-duration(short) gesso-easing(ease-in);
-
-  &:hover,
-  &:active {
-    outline: 0;
-  }
+  transition-duration: gesso-duration(short);
+  transition-property: background-color, border-color, color, outline-color;
+  transition-timing-function: gesso-easing(ease-in);
 
   &:hover,
   &:focus {

--- a/source/_patterns/04-components/form-item/_form-item.scss
+++ b/source/_patterns/04-components/form-item/_form-item.scss
@@ -72,16 +72,20 @@ $form-text-size: gesso-base-font-size() !default;
   transition-property: background-color, border;
   transition-timing-function: gesso-easing(ease-in-out);
 
+  &:focus {
+    @include focus();
+  }
+
   &:hover,
   &:focus {
     background-color: $form-background-color-focus;
     border: 1px solid $form-border-color-focus;
-    outline: 0;
   }
 
   &:disabled {
     cursor: default;
     opacity: $form-disabled-opacity;
+
     &:hover,
     &:focus {
       background-color: $form-background-color;

--- a/source/_patterns/04-components/form-item/form-item--checkbox/_form-item--checkbox.scss
+++ b/source/_patterns/04-components/form-item/form-item--checkbox/_form-item--checkbox.scss
@@ -13,6 +13,7 @@
     display: block;
 
     &::before {
+      @include focus();
       background: gesso-color(form, background-unchecked);
       border: 1px solid gesso-color(form, border-dark);
       content: '\a0';
@@ -38,7 +39,7 @@
   }
 
   &:focus + .form-item__label::before {
-    box-shadow: $form-box-shadow-focus;
+    outline-color: gesso-color(ui, generic, focus);
   }
 
   &:disabled + .form-item__label {

--- a/source/_patterns/04-components/form-item/form-item--radio/_form-item--radio.scss
+++ b/source/_patterns/04-components/form-item/form-item--radio/_form-item--radio.scss
@@ -5,6 +5,7 @@
   margin-bottom: gesso-spacing(xs);
 
   .form-item__radio {
+    @include focus();
     appearance: none;
     background-color: gesso-color(form, background-unchecked);
     border: 1px solid gesso-color(form, border-dark);

--- a/source/_patterns/04-components/form-item/form-item--range/_form-item--range.scss
+++ b/source/_patterns/04-components/form-item/form-item--range/_form-item--range.scss
@@ -9,6 +9,7 @@ $form-range-track-border-width: 1px !default;
 $form-range-track-height: 10px !default;
 
 @mixin form-item__range-thumb {
+  @include focus();
   background: gesso-color(form, thumb);
   border: $form-range-thumb-border-width solid gesso-color(form, border-light);
   border-radius: $form-range-thumb-border-radius;
@@ -20,7 +21,7 @@ $form-range-track-height: 10px !default;
 }
 
 @mixin form-item__range-thumb-focus {
-  box-shadow: $form-box-shadow-focus;
+  outline-color: gesso-color(ui, generic, focus);
 }
 
 @mixin form-item__range-track {

--- a/source/_patterns/04-components/mobile-menu-button/_mobile-menu-button.scss
+++ b/source/_patterns/04-components/mobile-menu-button/_mobile-menu-button.scss
@@ -2,6 +2,7 @@
 // Styles for the mobile menu buttons.
 
 .mobile-menu-button {
+  @include focus();
   background-color: transparent;
   border: 0;
   border-radius: 0;
@@ -15,10 +16,6 @@
   margin: 0;
   padding: 0 gesso-spacing(sm);
   text-decoration: none;
-
-  &:focus {
-    outline: thin dotted;
-  }
 }
 
 .mobile-menu-button__icon {

--- a/source/_patterns/04-components/mobile-menu/_mobile-menu.scss
+++ b/source/_patterns/04-components/mobile-menu/_mobile-menu.scss
@@ -66,6 +66,7 @@ $mobile-menu-line-height: gesso-line-height(base);
 }
 
 .mobile-menu__subnav-arrow {
+  @include focus();
   @include image-replace($mobile-menu-button-width, $mobile-menu-button-height);
   @include svg-background-inline(mobile-arrow-down);
   background-attachment: initial;
@@ -77,6 +78,7 @@ $mobile-menu-line-height: gesso-line-height(base);
   box-shadow: none;
   cursor: pointer;
   display: inline-block;
+  outline-offset: 0;
   position: absolute;
   right: 0;
   top: 0;
@@ -88,10 +90,6 @@ $mobile-menu-line-height: gesso-line-height(base);
       left: 0;
       right: auto;
     }
-  }
-
-  &:focus {
-    outline: thin dotted;
   }
 
   &[aria-expanded="true"] {


### PR DESCRIPTION
I added a focus mixin with a new default focus style that can be applied to multiple components.

Old default focus style:
![image](https://user-images.githubusercontent.com/135259/69070096-959db680-09f5-11ea-88e2-68e2d7d1f878.png)

New default focus style:
![image](https://user-images.githubusercontent.com/135259/69070127-9fbfb500-09f5-11ea-98c2-5543b50dc222.png)
