### PR TITLE
Fix color of visited button links

### DIFF
--- a/source/_patterns/00-config/01-mixins/_mixins.button.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.button.scss
@@ -55,6 +55,10 @@ $button-font-size: gesso-base-font-size() !default;
   vertical-align: top;
   white-space: normal;
 
+  &:visited {
+    color: $color-text;
+  }
+
   &:hover,
   &:focus {
     background-color: $color-background-hover;


### PR DESCRIPTION
No visited color is set for button links, so they get the default visited link color.

![image](https://user-images.githubusercontent.com/135259/69070687-9aaf3580-09f6-11ea-9c69-f5be4cb4a168.png)
