### PR TITLE
Update blockquote content margins

### DIFF
--- a/source/_patterns/02-base/02-html-elements/16-blockquote/_blockquote.scss
+++ b/source/_patterns/02-base/02-html-elements/16-blockquote/_blockquote.scss
@@ -18,7 +18,6 @@ blockquote {
     font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
-    margin-bottom: 0;
 
     &::before {
       content: '\201C';
@@ -40,6 +39,10 @@ blockquote {
       margin-left: rem(gesso-spacing(xxs));
       padding-left: rem(gesso-spacing(xs));
     }
+  }
+
+  :last-child {
+    margin-bottom: 0;
   }
 
   @media print {


### PR DESCRIPTION
I added the bottom margin back to `<p>` because there may be cases where a blockquote has more than one. I also remove the bottom-margin of the `last-child` of the blockquote so it doesn’t conflict with the bockquote margin.