### PR TITLE
Add link-active design token

### DIFF
--- a/source/_patterns/00-config/config.design-tokens.yml
+++ b/source/_patterns/00-config/config.design-tokens.yml
@@ -64,6 +64,7 @@ gesso:
       on-dark: grayscale.white
       link: brand.blue.base
       link-hover: brand.blue.dark
+      link-active: brand.blue.dark
       link-visited: brand.blue.dark
     background:
       site: grayscale.white

--- a/source/_patterns/02-base/02-html-elements/15-inline-elements/_inline-elements.scss
+++ b/source/_patterns/02-base/02-html-elements/15-inline-elements/_inline-elements.scss
@@ -19,7 +19,7 @@ a {
   }
 
   &:active {
-    color: gesso-color(text, link-hover);
+    color: gesso-color(text, link-active);
   }
 
   &:visited {


### PR DESCRIPTION
I added a `link-active` design token so that’s it’s easier to update the active link color on projects.