### PR TITLE
Remove Sass @debug statements

### DIFF
--- a/source/_patterns/00-config/00-functions/_00-functions.gesso.scss
+++ b/source/_patterns/00-config/00-functions/_00-functions.gesso.scss
@@ -36,8 +36,6 @@
   @return gesso-get-map(breakpoints, $keys...);
 }
 
-// @debug 'Gesso Breakpoint' gesso-breakpoint(sm);
-
 // Get Palette
 @function gesso-brand($keys...) {
   @return gesso-get-map(palette, brand, $keys...);
@@ -46,8 +44,6 @@
 @function gesso-grayscale($keys...) {
   @return gesso-get-map(palette, grayscale, $keys...);
 }
-
-// @debug 'Gesso Grayscale'  gesso-grayscale(grayscale-1);
 
 // Get Color
 @function gesso-color($keys...) {

--- a/source/_patterns/00-config/01-mixins/_mixins.display-text-style.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.display-text-style.scss
@@ -2,15 +2,11 @@
   $display: gesso-get-map(typography, display, $keys...);
 
   @each $property, $value in $display {
-    // @debug #{$property} $value;
-
     @if ($property == "font-size") {
-      //check for px if not output value
-      // @debug type-of($value);
+      // Check for px if not output value.
       #{$property}: #{rem(convert($value))};
     } @else {
       #{$property}: #{$value};
     }
   }
-
 }


### PR DESCRIPTION
I removed all Sass `@debug` statements, even though they were already commented out.