### PR TITLE
Drush improvements

### DIFF
--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -24,6 +24,12 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
   use SiteAliasManagerAwareTrait;
 
   /**
+   * Set of available themes.
+   * @var array
+   */
+  protected $themeList;
+
+  /**
    * Create a new theme based on the Gesso theme.
    *
    * @param $name
@@ -160,10 +166,12 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
    * Checks if $theme_name already exists in Drupal.
    */
   private function gesso_theme_exists($theme_name) {
-    $theme_handler = \Drupal::service('theme_handler');
-    $themes = $theme_handler->rebuildThemeData();
+    if (empty($this->themeList)) {
+      $theme_handler = \Drupal::service('theme_handler');
+      $this->themeList = $theme_handler->rebuildThemeData();
+    }
 
-    return isset($themes[$theme_name]);
+    return isset($this->themeList[$theme_name]);
   }
 
   /**

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -105,6 +105,11 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
     $new_libraries_file = Path::join($new_path, $machine_name . '.libraries.yml');
     drush_op('rename', $gesso_libraries_file, $new_libraries_file);
 
+    // Rename the .layouts.yml file.
+    $gesso_layouts_file = Path::join($new_path, 'gesso.layouts.yml');
+    $new_layouts_file = Path::join($new_path, $machine_name . '.layouts.yml');
+    drush_op('rename', $gesso_layouts_file, $new_layouts_file);
+
     // Rename the .theme file.
     $gesso_theme_file = Path::join($new_path, 'gesso.theme');
     $new_theme_file = Path::join($new_path, $machine_name . '.theme');
@@ -113,6 +118,7 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
     // Replace all occurrences of 'gesso' with the machine name of the new theme.
     $breakpoints_file = $machine_name . '.breakpoints.yml';
     $libraries_file = $machine_name . '.libraries.yml';
+    $layouts_file = $machine_name . '.layouts.yml';
     $theme_file = $machine_name . '.theme';
     $files = [
       $breakpoints_file,

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -161,7 +161,7 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
    */
   private function gesso_theme_exists($theme_name) {
     $theme_handler = \Drupal::service('theme_handler');
-    $themes = $theme_handler->listInfo();
+    $themes = $theme_handler->rebuildThemeData();
 
     return isset($themes[$theme_name]);
   }

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -112,7 +112,6 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
       $breakpoints_file,
       $libraries_file,
       $theme_file,
-      'js/scripts.js',
       'includes/block.inc',
       'includes/field.inc',
       'includes/form.inc',

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -137,10 +137,6 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
     // Warn the user that they might have some additional steps.
     $this->io()->caution(dt('If you want to remove the gesso theme entirely, be sure to copy and rename the '
      . 'gesso_helper module first.'));
-    $this->io()->note(dt('The gulp commands for !name are still gessoBuild and gessoWatch. If you want to change '
-      . 'those, you will need to modify the gulpfile and any build processes and/or CI tools.', [
-        '!name' => $name,
-    ]));
   }
 
   /**

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -70,6 +70,7 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
         . 'with a letter and may only contain lowercase letters, numbers, and underscores.'));
     }
 
+    $this->io()->text(dt('Setting up the theme. This may take a while...'));
     // Get theme paths.
     $drupalRoot = Drush::bootstrapManager()->getRoot();
     $gesso_path = Path::join($drupalRoot, drupal_get_path('theme', 'gesso'));
@@ -124,6 +125,7 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
       $breakpoints_file,
       $libraries_file,
       $theme_file,
+      $layouts_file,
       'includes/block.inc',
       'includes/field.inc',
       'includes/form.inc',
@@ -133,7 +135,7 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
       'includes/views.inc',
     ];
     foreach ($files as $file) {
-      $this->gesso_file_str_replace(Path::join($new_path, $file), 'gesso', $machine_name);
+      $this->gesso_file_str_replace(Path::join($new_path, $file), ['gesso', 'Gesso'], [$machine_name, $name]);
     }
 
     // Notify user of the newly created theme.

--- a/gesso_helper/src/TwigExtension/GessoExtensionLoader.php
+++ b/gesso_helper/src/TwigExtension/GessoExtensionLoader.php
@@ -24,12 +24,16 @@ class GessoExtensionLoader {
     $themeLocation = drupal_get_path('theme', $theme);
     $themePath = DRUPAL_ROOT . '/' . $themeLocation . '/';
     $fullPath = $themePath . 'source/_twig-components/functions/';
-    static::load($fullPath . 'add_attributes.function.drupal.php');
+    if (is_dir($fullPath)) {
+      static::load($fullPath . 'add_attributes.function.drupal.php');
+    }
   }
 
   static protected function load($file) {
-    include $file;
-    self::$objects[] = $function;
+    if (file_exists($file)) {
+      include $file;
+      self::$objects[] = $function;
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #268. You should no longer get PHP warnings if Gesso or a Gesso-based theme isn't your default theme, and you should be able to run `drush gesso "Your Theme Name"` successfully if the Gesso theme is in your themes folder, even if you haven't enabled it in Drupal. Also handles some other small issues I saw while working on this:

- .layouts.yml file gets renamed too
- Removed references to files that are no longer part of Gesso
- Updated the post-theme-creation message to remove the note about `gessoWatch` and `gessoBuild`
- Both the theme machine_name and the theme name get updated now

To test that this works for you, try both repeating the steps in #268 (enabling Gesso Helper with Bartik or some other theme as your default theme) and verify that you do not get PHP warnings with running drush commands and running through `drush gesso`.