### PR TITLE
Add dark background option for Pattern Lab components

### DIFF
--- a/source/pattern-lab.scss
+++ b/source/pattern-lab.scss
@@ -333,3 +333,25 @@ $swatch-padding: 1rem;
 .pattern-lab-text-style__label {
   text-transform: uppercase;
 }
+
+// For components used on a dark background. (e.g., `--inverse` variants)
+$dark-bg-padding: 1em;
+
+/* stylelint-disable selector-max-id */
+[id*="--inverse"].pl-c-pattern {
+  background: #212121;
+  color: #fff;
+  margin-left: -$dark-bg-padding;
+  margin-right: -$dark-bg-padding;
+  padding: 0 $dark-bg-padding $dark-bg-padding;
+
+  .pl-c-pattern__title-link:hover,
+  .pl-c-pattern__title-link:focus {
+    color: #fff !important;
+  }
+
+  .pl-c-pattern__extra {
+    color: #212121;
+  }
+}
+/* stylelint-enable */


### PR DESCRIPTION
Changes
* Add a dark background and adjust padding for PL components that need one such as `--inverse` variants

This will be applied by default to any component that has `--inverse` in the component name.

**Example from a recent project:**

Before
![image](https://user-images.githubusercontent.com/135259/69681088-f7f05a00-107a-11ea-8edb-0ccc23cee727.png)

After
![image](https://user-images.githubusercontent.com/135259/69681095-fcb50e00-107a-11ea-99ed-3e7e5816453c.png)
