### PR TITLE
Color token order

### DIFF
--- a/source/_patterns/01-global/00-colors/color.twig
+++ b/source/_patterns/01-global/00-colors/color.twig
@@ -1,138 +1,39 @@
+<h3>Brand</h3>
 <div class="pattern-lab-color">
-  <h4>Brand</h4>
-
   {% for key, list in gesso.palette.brand %}
-    {% set light = {} %}
-    {% set dark = {} %}
-    {% set base = {} %}
-    {% set other = {} %}
-
     <div class="pattern-lab-color__group">
-      {% for color_key, color in list %}
-
-        {% if color_key starts with 'light' %}
-          {% set light = light|merge({(color_key) : color}) %}
-        {% elseif color_key starts with 'dark' %}
-          {% set dark = dark|merge({(color_key) : color}) %}
-        {% elseif color_key starts with 'base' %}
-          {% set base = base|merge({(color_key) : color}) %}
-        {% else %}
-          {% set other = other|merge({(color_key) : color}) %}
-        {% endif %}
-
+      {% for name, color in list %}
+        {% include '@global/00-colors/_color-item.twig' with  {
+          color: color,
+          name: key ~'-'~ name
+        } %}
       {% endfor %}
-
-      {% if base|length > 0 %}
-        {% for base_key, base_value in base %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: base_value,
-                name: key ~'-'~ base_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if light|length > 0 %}
-        {% for light_key, light_value in light %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: light_value,
-                name: key ~'-'~ light_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if dark|length > 0 %}
-        {% for dark_key, dark_value in dark %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: dark_value,
-                 name: key ~'-'~ dark_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if other|length > 0 %}
-        {% for other_key, other_value in other %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: other_value,
-                name: key ~'-'~ other_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
     </div>
   {% endfor %}
 </div>
 
-<h4>Grayscale</h4>
+<h3>Grayscale</h3>
 <div class="pattern-lab-color">
   <div class="pattern-lab-color__group">
     {% for name, color in gesso.palette.grayscale %}
       {% include '@global/00-colors/_color-item.twig' with  {
         color: color,
-          name: name
+        name: name
       } %}
     {% endfor %}
   </div>
 </div>
 
-<h4>Other</h4>
+<h3>Other</h3>
 <div class="pattern-lab-color">
   {% for key, list in gesso.palette.other %}
-    {% set light = {} %}
-    {% set dark = {} %}
-    {% set base = {} %}
-    {% set other = {} %}
-
     <div class="pattern-lab-color__group">
-      {% for color_key, color in list %}
-
-        {% if color_key starts with 'light' %}
-          {% set light = light|merge({(color_key) : color}) %}
-        {% elseif color_key starts with 'dark' %}
-          {% set dark = dark|merge({(color_key) : color}) %}
-        {% elseif color_key starts with 'base' %}
-          {% set base = base|merge({(color_key) : color}) %}
-        {% else %}
-          {% set other = other|merge({(color_key) : color}) %}
-        {% endif %}
-
+      {% for name, color in list %}
+        {% include '@global/00-colors/_color-item.twig' with  {
+          color: color,
+          name: key ~'-'~ name
+        } %}
       {% endfor %}
-
-      {% if base|length > 0 %}
-        {% for base_key, base_value in base %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: base_value,
-                name: key ~'-'~ base_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if light|length > 0 %}
-        {% for light_key, light_value in light %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: light_value,
-                name: key ~'-'~ light_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if dark|length > 0 %}
-        {% for dark_key, dark_value in dark %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: dark_value,
-                 name: key ~'-'~ dark_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
-      {% if other|length > 0 %}
-        {% for other_key, other_value in other %}
-          {% include '@global/00-colors/_color-item.twig' with  {
-                color: other_value,
-                name: key ~'-'~ other_key
-              } %}
-        {% endfor %}
-      {% endif %}
-
     </div>
   {% endfor %}
 </div>


### PR DESCRIPTION
**Changes:**
- Refactor color twig template to output colors in the same order as they are defined in the design tokens yaml file
- Change color headings from `<h4>` to `<h3>` to match page heading structure

This work doesn’t change the current order colors are shown in Pattern Lab, but it allows one to change the order in the design tokens yaml file and see that change reflected in the generated Pattern Lab page.