### PR TITLE
Use dedicated forumone/gesso image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,4 @@
-FROM php:7.3-cli
-
-ENV NODE_VERSION=v12.13.0 \
-  NODE_CHECKSUM=c69671c89d0faa47b64bd5f37079e4480852857a9a9366ee86cdd8bc9670074a
-
-ENV NODE_FILENAME=node-${NODE_VERSION}-linux-x64.tar.gz
-
-RUN set -ex \
-  && cd /tmp \
-  && curl -fsSO "https://nodejs.org/dist/${NODE_VERSION}/${NODE_FILENAME}" \
-  && echo "${NODE_CHECKSUM}  ${NODE_FILENAME}" | sha256sum -c \
-  && tar xf "${NODE_FILENAME}" --strip-components=1 -C /usr/local \
-  && rm "${NODE_FILENAME}" \
-  && npm i -g gulp-cli
-
-WORKDIR /app
+FROM forumone/gesso:php7.3-node12
 
 COPY package*.json ./
 RUN if test -e package-lock.json; then npm ci; else npm i; fi


### PR DESCRIPTION
This replaces the image build steps for Gesso with the dedicated  [forumone/gesso](https://hub.docker.com/r/forumone/gesso) image on the Docker Hub. This image is Alpine-based to reduce disk space usage of the base image, and the centralized image should make it easier to ship updates to the build environment (for example, raising the Node.js or PHP versions).

This has been tested with fresh copies of Gesso as well as a few existing projects, so it should be ready for more widespread adoption.