### PR TITLE
Change webpack source map methods

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,12 @@ const TerserJsPlugin = require('terser-webpack-plugin');
 const glob = require('glob');
 const path = require('path');
 
-module.exports = (mode) => {
+module.exports = mode => {
   const isProduction = mode === 'production';
   const isDevelopment = !isProduction;
   const sourceFiles = glob.sync('js/src/*.es6.js');
   const entry = {};
-  sourceFiles.forEach((file) => {
+  sourceFiles.forEach(file => {
     const key = path.basename(file, '.es6.js');
     entry[key] = `./${file}`;
   });
@@ -18,43 +18,46 @@ module.exports = (mode) => {
     optimization: {
       splitChunks: {
         chunks: 'all',
-        name: 'common'
+        name: 'common',
       },
       minimizer: [
         new TerserJsPlugin({
           sourceMap: true,
           terserOptions: {
-            comments: false
+            comments: false,
           },
-        })
-      ]
+        }),
+      ],
     },
-    devtool: isDevelopment ? 'eval-source-map' : 'source-map',
+    devtool: isDevelopment ? 'source-map' : false,
     output: {
       path: `${__dirname}/js/dist`,
-      filename: '[name].min.js'
+      filename: '[name].min.js',
     },
     module: {
       rules: [
         {
           test: /\.js?$/,
           exclude: /node_modules/,
-          use: [{
-            loader: 'babel-loader',
-          }, {
-            loader: 'eslint-loader',
-            options: {
-              configFile: path.resolve(__dirname, '.eslintrc.js')
-            }
-          }],
+          use: [
+            {
+              loader: 'babel-loader',
+            },
+            {
+              loader: 'eslint-loader',
+              options: {
+                configFile: path.resolve(__dirname, '.eslintrc.js'),
+              },
+            },
+          ],
         },
-      ]
+      ],
     },
     externals: {
       jquery: 'jQuery',
       drupal: 'Drupal',
       drupalSettings: 'drupalSettings',
-      modernizr: 'Modernizr'
-    }
+      modernizr: 'Modernizr',
+    },
   };
 };


### PR DESCRIPTION
Addresses #313 . When not in production mode (running `gulp`), switches the webpack source map generator tool from `eval-source-map` to `source-map`. `eval-source-map` is typically recommended for development because it's faster when rebuilding files (or so https://webpack.js.org/configuration/devtool/ told me) but apparently doesn't play nicely when Drupal's aggregate JS and CSS are turned on.

This PR also switches the source map tool to none when in production mode (running `gulp build`), again following the recommendations of the webpack docs. In both cases, these are the default starting options, but developers on individual projects can override them by editing webpack.config.js for their individual projects.

Finally, I fixed some formatting issues that the ESLint plugin for PHPStorm flagged for me while I was working.

*Note for Testing*
If you have an existing testing site, you'll need to run `f1 build` or otherwise rebuild your Gesso container in order to copy the updated webpack config into the container before trying to build the front-end.