### PR TITLE
Watch Markdown files; Adjust regex for variables section

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -164,6 +164,13 @@ const watchFiles = () => {
     { usePolling: true, interval: 1500 },
     bundleScriptsDev
   );
+  watch(
+    [
+      'source/**/*.md',
+    ],
+    { usePolling: true, interval: 1500 },
+    lintPatterns
+  )
 };
 
 const buildStyles = (exports.buildStyles = series(lintStyles, compileStyles));

--- a/lib/lintPatternLab.js
+++ b/lib/lintPatternLab.js
@@ -109,7 +109,7 @@ lintMarkdownFiles.lintFile = function(file) {
             );
           }
           // Check that variables list uses correct syntax.
-          const variablesTest = /\S*Variables\S*[\n\r]((?:[\s\t]*\* .+[\n\r])+)/;
+          const variablesTest = /__Variables:__\s*(?:\r|\n|\r\n)((?:\s*\t*\*.+((?:\r|\n|\r\n)|\.))+)/;
           const variableLineTest = /\* ([^:]+): \[([^\]]+)\] (.*)/;
           const variablesResults = variablesTest.exec(fileContents);
           if (variablesResults[1]) {


### PR DESCRIPTION
Closes #321 . Adjusts the regex that identifies the Variables section of a pattern lab markdown file to handle the case where there is no new line or carriage return at the end.

Also adds a watch task for markdown files, so you can get immediate feedback from the linter when editing those files without having to also update the twig file.