### PR TITLE
Add unique ID filter to Twig

### DIFF
--- a/gesso_helper/src/TwigExtension/GessoExtensionAdapter.php
+++ b/gesso_helper/src/TwigExtension/GessoExtensionAdapter.php
@@ -11,7 +11,11 @@ class GessoExtensionAdapter extends \Twig_Extension {
   }
 
   public function getFunctions() {
-    return GessoExtensionLoader::get();
+    return GessoExtensionLoader::getFunctions();
+  }
+
+  public function getFilters() {
+    return GessoExtensionLoader::getFilters();
   }
 
 }

--- a/gesso_helper/src/TwigExtension/GessoExtensionLoader.php
+++ b/gesso_helper/src/TwigExtension/GessoExtensionLoader.php
@@ -7,32 +7,52 @@ namespace Drupal\gesso_helper\TwigExtension;
  */
 class GessoExtensionLoader {
 
-  static $objects = [];
+  static $functions = [];
+  static $filters = [];
 
   static public function init() {
-    if (!self::$objects) {
-      static::loadAll();
+    if (!self::$functions) {
+      static::loadAllFunctions();
+    }
+    if (!self::$filters) {
+      static::loadAllFilters();
     }
   }
 
-  static public function get() {
-    return !empty(self::$objects) ? self::$objects : [];
+  static public function getFunctions() {
+    return !empty(self::$functions) ? self::$functions : [];
   }
 
-  static protected function loadAll() {
+  static public function getFilters() {
+    return !empty(self::$filters) ? self::$filters : [];
+  }
+
+  static protected function getThemePath() {
     $theme = \Drupal::config('system.theme')->get('default');
     $themeLocation = drupal_get_path('theme', $theme);
-    $themePath = DRUPAL_ROOT . '/' . $themeLocation . '/';
+    return DRUPAL_ROOT . '/' . $themeLocation . '/';
+  }
+
+  static protected function loadAllFunctions() {
+    $themePath = self::getThemePath();
     $fullPath = $themePath . 'source/_twig-components/functions/';
     if (is_dir($fullPath)) {
-      static::load($fullPath . 'add_attributes.function.drupal.php');
+      static::load($fullPath . 'add_attributes.function.drupal.php', self::$functions);
     }
   }
 
-  static protected function load($file) {
+  static protected function loadAllFilters() {
+    $themePath = self::getThemePath();
+    $fullPath = $themePath . 'source/_twig-components/filters/';
+    if (is_dir($fullPath)) {
+      static::load($fullPath . 'unique_id.filter.drupal.php', self::$filters);
+    }
+  }
+
+  static protected function load($file, &$collection) {
     if (file_exists($file)) {
       include $file;
-      self::$objects[] = $function;
+      $collection[] = $function;
     }
   }
 

--- a/pattern-lab-config.json
+++ b/pattern-lab-config.json
@@ -225,6 +225,10 @@
           "functions": ["addKeySortFilter"]
         },
         {
+          "file": "source/_twig-components/filters/unique_id.filter.patternlab.php",
+          "functions": ["addUniqueIdFilter"]
+        },
+        {
           "file": "source/_twig-components/functions/add_attributes.function.patternlab.php",
           "functions": ["addAddAttributesFunction"]
         },

--- a/source/_patterns/04-components/breadcrumb/breadcrumb.twig
+++ b/source/_patterns/04-components/breadcrumb/breadcrumb.twig
@@ -3,9 +3,11 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
-<nav aria-labelled="breadcrumb-label" class="{{ classes }}" role="navigation">
+{% set breadcrumb_label = 'breadcrumb-label'|unique_id %}
+
+<nav aria-labelled="{{ breadcrumb_label }}" class="{{ classes }}" role="navigation">
   <div class="l-constrain">
-    <h2 class="breadcrumb__title visually-hidden" id="breadcrumb-label">{{ heading|default('You are here') }}</h2>
+    <h2 class="breadcrumb__title visually-hidden" id="{{ breadcrumb_label }}">{{ heading|default('You are here') }}</h2>
     <ol class="breadcrumb__list">
       {% for item in breadcrumb %}
         <li class="breadcrumb__item">

--- a/source/_patterns/04-components/breadcrumb/breadcrumb.twig
+++ b/source/_patterns/04-components/breadcrumb/breadcrumb.twig
@@ -3,11 +3,11 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
-{% set breadcrumb_label = 'breadcrumb-label'|unique_id %}
+{% set breadcrumb_id = 'breadcrumb-label'|unique_id %}
 
-<nav aria-labelled="{{ breadcrumb_label }}" class="{{ classes }}" role="navigation">
+<nav aria-labelled="{{ breadcrumb_id }}" class="{{ classes }}" role="navigation">
   <div class="l-constrain">
-    <h2 class="breadcrumb__title visually-hidden" id="{{ breadcrumb_label }}">{{ heading|default('You are here') }}</h2>
+    <h2 class="breadcrumb__title visually-hidden" id="{{ breadcrumb_id }}">{{ heading|default('You are here') }}</h2>
     <ol class="breadcrumb__list">
       {% for item in breadcrumb %}
         <li class="breadcrumb__item">

--- a/source/_patterns/04-components/pager/pager--mini/pager--mini.twig
+++ b/source/_patterns/04-components/pager/pager--mini/pager--mini.twig
@@ -1,6 +1,7 @@
+{% set pagination_heading_id = 'pagination-heading'|unique_id %}
 {% if items.previous or items.next %}
-  <nav class="pager pager--mini" role="navigation" aria-labelledby="pagination-heading">
-    <h4 id="pagination-heading" class="visually-hidden">{{ heading|default('Pagination') }}</h4>
+  <nav class="pager pager--mini" role="navigation" aria-labelledby="{{ pagination_heading_id }}">
+    <h4 id="{{ pagination_heading_id }}" class="visually-hidden">{{ heading|default('Pagination') }}</h4>
     <ul class="pager__items js-pager__items">
 
       {% if items.previous %}

--- a/source/_twig-components/filters/unique_id.filter.drupal.php
+++ b/source/_twig-components/filters/unique_id.filter.drupal.php
@@ -1,0 +1,7 @@
+<?php
+/*
+ * @file
+ * Twig filter to use Drupal's getUniqueId function to create unique HTML IDs.
+ */
+
+$function = new \Twig_SimpleFilter('unique_id', '\\Drupal\\Component\\Utility\\Html::getUniqueId');

--- a/source/_twig-components/filters/unique_id.filter.patternlab.php
+++ b/source/_twig-components/filters/unique_id.filter.patternlab.php
@@ -6,6 +6,6 @@
  */
 function addUniqueIdFilter(\Twig_Environment &$env, $config) {
   $env->addFilter(new \Twig_SimpleFilter('unique_id', function($string) {
-    return $string . '--' . rand();
+    return $string . '--' . uniqid();
   }));
 }

--- a/source/_twig-components/filters/unique_id.filter.patternlab.php
+++ b/source/_twig-components/filters/unique_id.filter.patternlab.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @file
+ * Twig filter to polyfill the unique_id filter for Pattern Lab.
+ */
+function addUniqueIdFilter(\Twig_Environment &$env, $config) {
+  $env->addFilter(new \Twig_SimpleFilter('unique_id', function($string) {
+    return $string . '--' . rand();
+  }));
+}


### PR DESCRIPTION
Drupal 8 includes [Html::getUniqueId](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Component%21Utility%21Html.php/function/Html%3A%3AgetUniqueId/8.2.x), which ensures that IDs aren't repeated on a page. This PR makes that functionality available as a Twig filter. For Pattern Lab, a unique ID is generated via the uniqid() function.

The typical use case for this is when you need to include an ID in multiple places in a pattern, such as in another element's ARIA attribute (as in the breadcrumbs pattern, which I updated here to use the new filter) or in a data attribute, particularly where the component might be used multiple times on a page. I usually find myself needing this with accordions.