### PR TITLE
Add options to set button border width and color

### DIFF
--- a/source/_patterns/00-config/01-mixins/_mixins.button.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.button.scss
@@ -1,6 +1,7 @@
 // @file
 // Button styles
 
+$button-border-width: 0 !default;
 $button-border-radius: 0 !default;
 $button-background-color: gesso-color(button, primary, background) !default;
 $button-background-color-active: gesso-color(
@@ -18,6 +19,8 @@ $button-background-color-hover: gesso-color(
   primary,
   background-hover
 ) !default;
+$button-border-color: gesso-color(button, primary, border) !default;
+$button-border-color-hover: gesso-color(button, primary, border-hover) !default;
 $button-text-color: gesso-color(button, primary, text) !default;
 $button-text-color-active: gesso-color(button, primary, text-active) !default;
 $button-text-color-disabled: gesso-color(button, disabled, text) !default;
@@ -27,17 +30,24 @@ $button-font-size: gesso-base-font-size() !default;
 @mixin button(
   $color-background: $button-background-color,
   $color-text: $button-text-color,
+  $color-border: $button-border-color,
   $color-background-hover: $button-background-color-hover,
   $color-text-hover: $button-text-color-hover,
+  $color-border-hover: $button-border-color-hover,
   $color-background-active: $button-background-color-active,
   $color-text-active: $button-text-color-active,
   $color-background-disabled: $button-background-color-disabled,
   $color-text-disabled: $button-text-color-disabled,
   $border-radius: $button-border-radius,
+  $border-width: $button-border-width,
   $font-size: $button-font-size
 ) {
   background-color: $color-background;
-  border: 0;
+  @if $border-width != 0 {
+    border: $border-width solid $color-border;
+  } @else {
+    border: 0;
+  }
   border-radius: $border-radius;
   color: $color-text;
   cursor: pointer;
@@ -62,6 +72,9 @@ $button-font-size: gesso-base-font-size() !default;
   &:hover,
   &:focus {
     background-color: $color-background-hover;
+    @if $border-width != 0 {
+      border-color: $color-border-hover;
+    }
     color: $color-text-hover;
   }
 

--- a/source/_patterns/00-config/config.design-tokens.yml
+++ b/source/_patterns/00-config/config.design-tokens.yml
@@ -76,6 +76,8 @@ gesso:
         background: brand.blue.base
         background-hover: brand.blue.dark
         background-active: brand.blue.dark-1
+        border: brand.blue.base
+        border-hover: brand.blue.dark
         text: grayscale.white
         text-hover: grayscale.white
         text-active: grayscale.white
@@ -83,6 +85,8 @@ gesso:
         background: brand.ocean-blue.base
         background-hover: brand.ocean-blue.dark
         background-active: brand.ocean-blue.dark-1
+        border: brand.ocean-blue.base
+        border-hover: brand.ocean-blue.dark-1
         text: grayscale.white
         text-hover: grayscale.white
         text-active: grayscale.white
@@ -93,6 +97,8 @@ gesso:
         background: other.red.base
         background-hover: other.red.dark
         background-active: other.red.dark-1
+        border: other.red.base
+        border-hover: other.red.dark
         text: grayscale.white
         text-hover: grayscale.white
         text-active: grayscale.white

--- a/source/_patterns/04-components/button/_button.scss
+++ b/source/_patterns/04-components/button/_button.scss
@@ -37,12 +37,12 @@
 // This custom button class, included as an example, is not output by Drupal by default.
 .button--secondary {
   @include button(
-    gesso-color(button, secondary, background),
-    gesso-color(button, secondary, text),
-    gesso-color(button, secondary, background-hover),
-    gesso-color(button, secondary, text-hover),
-    gesso-color(button, secondary, background-active),
-    gesso-color(button, secondary, text-active)
+    $color-background: gesso-color(button, secondary, background),
+    $color-text: gesso-color(button, secondary, text),
+    $color-background-hover: gesso-color(button, secondary, background-hover),
+    $color-text-hover: gesso-color(button, secondary, text-hover),
+    $color-background-active: gesso-color(button, secondary, background-active),
+    $color-text-active: gesso-color(button, secondary, text-active)
   );
 }
 


### PR DESCRIPTION
Adds options to set border width and color for a button style, for use in creating outline-style buttons, e.g. https://designsystem.digital.gov/components/button/.