### PR TITLE
increased nesting depth, removed qualifying type check

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -11,7 +11,7 @@ rules:
     - never
     - ignore:
       - 'inside-function'
-  max-nesting-depth: 3
+  max-nesting-depth: 4
   no-empty-first-line: true
   order/order:
     - - type: at-rule
@@ -34,9 +34,6 @@ rules:
     #   ----------------------------------------------     -----------------------------------------------      -----------------------------------------------
     - '^[a-zA-Z][a-zA-Z0-9]*(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?$'
   selector-no-qualifying-type:
-    - true
-    - ignore:
-      - attribute
   string-no-newline: true
   scss/at-import-partial-extension-blacklist:
     - 'less'

--- a/source/_patterns/00-config/01-mixins/_mixins.list.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.list.scss
@@ -59,7 +59,6 @@
       }
     }
 
-    /* stylelint-disable-next-line selector-no-qualifying-type */
     &.is-active {
       font-weight: gesso-font-weight(bold);
     }

--- a/source/_patterns/02-base/02-html-elements/02-body/_body.scss
+++ b/source/_patterns/02-base/02-html-elements/02-body/_body.scss
@@ -8,10 +8,8 @@ body {
   padding: 0;
   word-wrap: break-word;
 
-  // stylelint-disable selector-no-qualifying-type
   &.has-open-mobile-menu {
     overflow: hidden;
     -webkit-overflow-scrolling: touch;
   }
-  // stylelint-enable
 }

--- a/source/_patterns/04-components/00-cms-styles/toolbar-menu/_toolbar-menu.scss
+++ b/source/_patterns/04-components/00-cms-styles/toolbar-menu/_toolbar-menu.scss
@@ -1,7 +1,6 @@
 // @file
 // Styles for the Toolbar module.
 
-/* stylelint-disable-next-line selector-no-qualifying-type */
 ul.toolbar-menu {
   @include list-clean;
 }

--- a/source/_patterns/04-components/details/_details.scss
+++ b/source/_patterns/04-components/details/_details.scss
@@ -9,12 +9,10 @@ $details-text-color: gesso-color(text, on-light) !default;
 
 // 'details' can appear as a modernizr class on the html tag, so this
 // class is limited to only the details element
-/* stylelint-disable-next-line selector-no-qualifying-type */
 details.details {
   @include vertical-spacing(rem(gesso-spacing(3)));
 
   // Fallback for browsers that don’t support details.
-  /* stylelint-disable-next-line selector-no-qualifying-type */
   .js &:not([open]) > .details__content {
     display: none;
   }


### PR DESCRIPTION
This increases the nesting limit from 3 to 4 (I wouldn't be opposed to making it 5, but thought we'd start with baby steps).

This also removes the qualifying selector check.  There are already four places in the default Gesso styles where we had to explicitly ignore this rule, and I often run into it in new components.  I don't think it's unreasonable to want to style classes differently based on the elements (e.g., a.button vs button.button or div.align-right vs figure.align-right) and I also don't think this is something people often do without good reason.   