### PR TITLE
adds captioned image component

### DIFF
--- a/source/_patterns/04-components/captioned-image/_captioned-image.scss
+++ b/source/_patterns/04-components/captioned-image/_captioned-image.scss
@@ -1,0 +1,27 @@
+// @file
+// Component: Captioned Image
+
+.captioned-image {
+  @media not speech {
+    display: table;
+    figcaption {
+      caption-side: bottom;
+      display: table-caption;
+    }
+  }
+}
+
+.captioned-image--center-aligned {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.captioned-image--left-aligned {
+  float: left;
+  margin-right: rem(gesso-spacing(3));
+}
+
+.captioned-image--right-aligned {
+  float: right;
+  margin-left: rem(gesso-spacing(3));
+}

--- a/source/_patterns/04-components/captioned-image/_captioned-image.scss
+++ b/source/_patterns/04-components/captioned-image/_captioned-image.scss
@@ -2,13 +2,12 @@
 // Component: Captioned Image
 
 .captioned-image {
-  @media not speech {
-    display: table;
-    figcaption {
-      caption-side: bottom;
-      display: table-caption;
-    }
-  }
+  display: table;
+}
+
+.captioned-image__caption {
+  caption-side: bottom;
+  display: table-caption;
 }
 
 .captioned-image--center-aligned {

--- a/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.md
+++ b/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.md
@@ -1,0 +1,9 @@
+---
+el: .captioned-image--center-aligned
+title: Center Aligned Captioned Image
+---
+
+__Variables:__
+* modifier_classes: [string] Classes to modify the default component styling.
+* media: [string] Image.
+* caption: [string] Text of the button.

--- a/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.twig
@@ -1,0 +1,10 @@
+{% set classes = [
+  'captioned-image--center-aligned',
+  modifier_classes ? modifier_classes,
+]|join(' ')|trim %}
+
+{% include '@components/captioned-image/captioned-image.twig' with {
+  'url': url,
+  'text': text,
+  'modifier_classes': classes,
+} %}

--- a/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.yml
+++ b/source/_patterns/04-components/captioned-image/captioned-image--center-aligned/captioned-image--center-aligned.yml
@@ -1,0 +1,3 @@
+---
+media: '<img src="https://picsum.photos/200/200?image=237" alt="dog photo">'
+caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla semper vel metus at cursus.'

--- a/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.md
+++ b/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.md
@@ -1,0 +1,9 @@
+---
+el: .captioned-image--left-aligned
+title: Left Aligned Captioned Image
+---
+
+__Variables:__
+* modifier_classes: [string] Classes to modify the default component styling.
+* media: [string] Image.
+* caption: [string] Text of the button.

--- a/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.twig
@@ -1,0 +1,10 @@
+{% set classes = [
+  'captioned-image--left-aligned',
+  modifier_classes ? modifier_classes,
+]|join(' ')|trim %}
+
+{% include '@components/captioned-image/captioned-image.twig' with {
+  'url': url,
+  'text': text,
+  'modifier_classes': classes,
+} %}

--- a/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.yml
+++ b/source/_patterns/04-components/captioned-image/captioned-image--left-aligned/captioned-image--left-aligned.yml
@@ -1,0 +1,3 @@
+---
+media: '<img src="https://picsum.photos/200/200?image=237" alt="dog photo">'
+caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla semper vel metus at cursus.'

--- a/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.md
+++ b/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.md
@@ -1,0 +1,9 @@
+---
+el: .captioned-image--right-aligned
+title: Right Aligned Captioned Image
+---
+
+__Variables:__
+* modifier_classes: [string] Classes to modify the default component styling.
+* media: [string] Image.
+* caption: [string] Text of the button.

--- a/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.twig
@@ -1,0 +1,10 @@
+{% set classes = [
+  'captioned-image--right-aligned',
+  modifier_classes ? modifier_classes,
+]|join(' ')|trim %}
+
+{% include '@components/captioned-image/captioned-image.twig' with {
+  'url': url,
+  'text': text,
+  'modifier_classes': classes,
+} %}

--- a/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.yml
+++ b/source/_patterns/04-components/captioned-image/captioned-image--right-aligned/captioned-image--right-aligned.yml
@@ -1,0 +1,3 @@
+---
+media: '<img src="https://picsum.photos/200/200?image=237" alt="dog photo">'
+caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla semper vel metus at cursus.'

--- a/source/_patterns/04-components/captioned-image/captioned-image.md
+++ b/source/_patterns/04-components/captioned-image/captioned-image.md
@@ -1,0 +1,9 @@
+---
+el: .captioned-image
+title: Captioned Image
+---
+
+__Variables:__
+* modifier_classes: [string] Classes to modify the default component styling.
+* media: [string] Image.
+* caption: [string] Text of the button.

--- a/source/_patterns/04-components/captioned-image/captioned-image.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image.twig
@@ -6,6 +6,6 @@
 <figure class="{{ classes }}">
   {{ media }}
   {% if caption %}
-    <figcaption>{{ caption }}</figcaption>
+    <figcaption class="captioned-image__caption">{{ caption }}</figcaption>
   {% endif %}
 </figure>

--- a/source/_patterns/04-components/captioned-image/captioned-image.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image.twig
@@ -1,0 +1,11 @@
+{% set classes = [
+  'captioned-image',
+  modifier_classes ? modifier_classes,
+]|join(' ')|trim %}
+
+<figure class="{{ classes }}">
+  {{ media }}
+  {% if caption %}
+    <figcaption>{{ caption }}</figcaption>
+  {% endif %}
+</figure>

--- a/source/_patterns/04-components/captioned-image/captioned-image.yml
+++ b/source/_patterns/04-components/captioned-image/captioned-image.yml
@@ -1,0 +1,3 @@
+---
+media: '<img src="https://picsum.photos/200/200?image=237" alt="dog photo">'
+caption: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla semper vel metus at cursus.'

--- a/source/_patterns/06-pages/article.twig
+++ b/source/_patterns/06-pages/article.twig
@@ -1,9 +1,18 @@
 {% set page_content %}
 
+  {% set body_content %}
+    {% include '@components/captioned-image/captioned-image.twig' with {
+      'modifier_classes': 'captioned-image--right-aligned',
+      'media': '<img src="https://picsum.photos/150/150?image=237" alt="dog photo">',
+      'caption': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+    } %}
+    {{ content }}
+  {% endset %}
+
   {# include article template #}
   {% include '@templates/article.twig' with {
     'article_title': title,
-    'article_content': content,
+    'article_content': body_content,
     'article_has_footer': true
   } %}
 


### PR DESCRIPTION
This adds a 'captioned-image' component with left, right and centered variants that allows the caption to auto-size with the included image.  I've limited the `display: table` styles to non-screen readers so that the caption doesn't get read twice.