### PR TITLE
removed word copyright

### DIFF
--- a/source/_patterns/04-components/copyright/copyright.twig
+++ b/source/_patterns/04-components/copyright/copyright.twig
@@ -1,3 +1,3 @@
 <div class="copyright">
-  &copy; {{ year.long }} Copyright {{ site_name }}.
+  &copy; {{ year.long }} {{ site_name }}.
 </div>


### PR DESCRIPTION
I removed the word "Copyright" from the Twig component. Most standard copyrights include the `&copy;` symbol, the year and site name. Having the word "Copyright" seems redundant and it ends up being deleted most of the times. Let me know!