### PR TITLE
Refactor component creation script

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -6,97 +6,89 @@ const inquirer = require('inquirer');
 const path = require('path');
 const mkdirp = require('mkdirp');
 
-const isDirectory = source => fs.lstatSync(source).isDirectory();
+const isDirectory = async source => {
+  const stats = await fs.promises.lstat(source);
+  return stats.isDirectory();
+};
 
-const getDirectories = source => {
-  return fs
-    .readdirSync(source)
+const getDirectories = async source => {
+  const directoryFiles = await fs.promises.readdir(source);
+  return directoryFiles
     .map(name => path.join(source, name))
     .filter(isDirectory);
 };
 
-init();
-
-function init() {
-  const patternSrc = `${process.cwd()}/source/_patterns/`;
-  const patternDir = getDirectories(patternSrc);
-
+async function getMachineName() {
   const questions = [
     {
       type: 'input',
-      name: 'component_name',
+      name: 'componentName',
       message: 'What is the name your component?',
       filter: machineName,
     },
   ];
-  inquirer
-    .prompt(questions)
-    .then(answers => {
-      const componentName = answers.component_name.trim();
-      const defaultComponentTitle = humanName(componentName);
-      const questions = [
-        {
-          type: 'input',
-          name: 'component_title',
-          message: 'What is the human-readable title of your component?',
-          default: defaultComponentTitle,
-        },
-        {
-          type: 'list',
-          name: 'component_folder',
-          message: 'Component Location',
-          choices: patternDir.map(item => path.basename(item)),
-        },
-        {
-          type: 'input',
-          name: 'component_folder_sub',
-          message: 'Include subfolder or leave blank',
-        },
-      ];
-      return inquirer
-        .prompt(questions)
-        .then(answers =>
-          Object.assign(answers, { component_name: componentName })
-        );
-    })
-    .then(answers => {
-      const componentName = answers.component_name;
-      const componentTitle = answers.component_title;
-      const componentDocumentation = answers.document;
-      const componentLocation = path.join(
-        patternSrc,
-        answers.component_folder,
-        machineName(answers.component_folder_sub),
-        machineName(componentName)
-      );
-      const output = `---
+  const { componentName } = await inquirer.prompt(questions);
+  return componentName.trim();
+}
+
+async function getComponentDetails(componentName, patternDir) {
+  const defaultComponentTitle = humanName(componentName);
+  const detailedQuestions = [
+    {
+      type: 'input',
+      name: 'componentTitle',
+      message: 'What is the human-readable title of your component?',
+      default: defaultComponentTitle,
+    },
+    {
+      type: 'list',
+      name: 'componentFolder',
+      message: 'Component Location',
+      choices: patternDir.map(item => path.basename(item)),
+    },
+    {
+      type: 'input',
+      name: 'componentFolderSub',
+      message: 'Include subfolder or leave blank',
+    },
+  ];
+  return await inquirer.prompt(detailedQuestions);
+}
+
+async function init() {
+  const patternSrc = `${process.cwd()}/source/_patterns/`;
+  const patternDir = await getDirectories(patternSrc);
+  const componentName = await getMachineName();
+  const {
+    componentTitle,
+    componentFolder,
+    componentFolderSub,
+  } = await getComponentDetails(componentName, patternDir);
+  const componentLocation = path.join(
+    patternSrc,
+    componentFolder,
+    machineName(componentFolderSub),
+    machineName(componentName)
+  );
+  const output = `---
 Component Name: ${componentName}
 Component Title: ${componentTitle}
 Component Location: ${componentLocation}
 `;
-      console.log(output);
-
-      const confirm = [
-        {
-          type: 'confirm',
-          name: 'confirm',
-          message: 'Is this what you want?',
-        },
-      ];
-
-      inquirer.prompt(confirm).then(answers => {
-        if (answers.confirm) {
-          createComponent(
-            componentName,
-            componentTitle,
-            componentLocation,
-            componentDocumentation
-          );
-        } else {
-          console.log('Component cancelled');
-        }
-      });
-    });
+  console.log(output);
+  const confirm = [
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Is this what you want?',
+    },
+  ];
+  const confirmation = await inquirer.prompt(confirm);
+  if (confirmation.confirm) {
+    await createComponent(componentName, componentTitle, componentLocation);
+  } else {
+    console.log('Component cancelled');
+  }
 }
 
 function machineName(name) {
@@ -113,22 +105,25 @@ function humanName(name) {
   return words.join(' ');
 }
 
-function createComponent(
-  componentName,
-  componentTitle,
-  location,
-  documentation
-) {
+async function createComponent(componentName, componentTitle, location) {
   if (fs.existsSync(location)) {
     console.log('Component directory already exists');
   } else {
     mkdirp(location)
-      .then(() => {
-        const filesArray = ['scss', 'twig', 'yml', 'md'];
-        filesArray.forEach(function(file) {
-          makeComponentFile(componentName, componentTitle, location, file);
-        });
-        console.log(`${componentTitle} created`);
+      .then(async () => {
+        const filesArray = ['scss', 'twig', 'yml', 'md'].map(
+          async ext =>
+            await makeComponentFile(
+              componentName,
+              componentTitle,
+              location,
+              ext
+            )
+        );
+        const success = await Promise.all(filesArray);
+        if (success) {
+          console.log(`${componentTitle} created`);
+        }
       })
       .catch(err => console.error(err));
   }
@@ -163,3 +158,5 @@ title: ${componentTitle}
     }
   });
 }
+
+init();

--- a/lib/component.js
+++ b/lib/component.js
@@ -52,11 +52,11 @@ async function getComponentDetails(componentName, patternDir) {
       message: 'Include subfolder or leave blank',
     },
   ];
-  return await inquirer.prompt(detailedQuestions);
+  return inquirer.prompt(detailedQuestions);
 }
 
 async function init() {
-  const patternSrc = `${process.cwd()}/source/_patterns/`;
+  const patternSrc = path.join(process.cwd(), 'source', '_patterns');
   const patternDir = await getDirectories(patternSrc);
   const componentName = await getMachineName();
   const {
@@ -76,15 +76,15 @@ Component Title: ${componentTitle}
 Component Location: ${componentLocation}
 `;
   console.log(output);
-  const confirm = [
+  const confirmQuestion = [
     {
       type: 'confirm',
       name: 'confirm',
       message: 'Is this what you want?',
     },
   ];
-  const confirmation = await inquirer.prompt(confirm);
-  if (confirmation.confirm) {
+  const { confirm } = await inquirer.prompt(confirmQuestion);
+  if (confirm) {
     await createComponent(componentName, componentTitle, componentLocation);
   } else {
     console.log('Component cancelled');
@@ -109,23 +109,19 @@ async function createComponent(componentName, componentTitle, location) {
   if (fs.existsSync(location)) {
     console.log('Component directory already exists');
   } else {
-    mkdirp(location)
-      .then(async () => {
-        const filesArray = ['scss', 'twig', 'yml', 'md'].map(
-          async ext =>
-            await makeComponentFile(
-              componentName,
-              componentTitle,
-              location,
-              ext
-            )
-        );
-        const success = await Promise.all(filesArray);
-        if (success) {
-          console.log(`${componentTitle} created`);
-        }
-      })
-      .catch(err => console.error(err));
+    try {
+      await mkdirp(location);
+    } catch (err) {
+      console.error(err);
+    }
+
+    const filesArray = ['scss', 'twig', 'yml', 'md'].map(ext =>
+      makeComponentFile(componentName, componentTitle, location, ext)
+    );
+    const success = await Promise.all(filesArray);
+    if (success) {
+      console.log(`${componentTitle} created`);
+    }
   }
 }
 
@@ -159,4 +155,6 @@ title: ${componentTitle}
   });
 }
 
-init();
+init().catch(err => {
+  console.error(err);
+});

--- a/lib/component.js
+++ b/lib/component.js
@@ -13,9 +13,9 @@ const isDirectory = async source => {
 
 const getDirectories = async source => {
   const directoryFiles = await fs.promises.readdir(source);
-  return directoryFiles
-    .map(name => path.join(source, name))
-    .filter(isDirectory);
+  const directoryPaths = directoryFiles.map(name => path.join(source, name));
+  const isDirectoryResults = await Promise.all(directoryPaths.map(isDirectory));
+  return directoryPaths.filter((value, index) => isDirectoryResults[index]);
 };
 
 async function getMachineName() {


### PR DESCRIPTION
Closes #336 . Reworks parts of the component generator script to use async/await instead of fs.*Sync methods and promise chaining, as was originally suggested in #334 . No changes to the functionality from an end-user perspective.