### PR TITLE
Fixes to slide toggle

### DIFF
--- a/js/src/modules/_slide.es6.js
+++ b/js/src/modules/_slide.es6.js
@@ -5,11 +5,13 @@
  * elements.
  */
 
+import 'custom-event-polyfill';
+
 /**
  * Slides target element up and out view.
  *
  * @name slideUp
- * @param {string} target - The element sliding up.
+ * @param {HTMLElement} target - The element sliding up.
  * @param {integer} duration - The duration of the animation, with default value 500.
  */
 export const slideUp = (target, duration = 500) => {
@@ -19,10 +21,10 @@ export const slideUp = (target, duration = 500) => {
     target.style.transitionDuration = `${duration}ms`;
     target.style.boxSizing = 'border-box';
     target.style.overflow = 'hidden';
-    target.style.paddingTop = 0;
-    target.style.paddingBottom = 0;
-    target.style.marginTop = 0;
-    target.style.marginBottom = 0;
+    target.style.paddingTop = '0';
+    target.style.paddingBottom = '0';
+    target.style.marginTop = '0';
+    target.style.marginBottom = '0';
 
     window.requestAnimationFrame(() => {
       function hideTarget() {
@@ -36,9 +38,11 @@ export const slideUp = (target, duration = 500) => {
         target.style.removeProperty('transition-duration');
         target.style.removeProperty('transition-property');
         target.removeEventListener('transitionend', hideTarget);
+        const event = new CustomEvent('finishslider', { detail: target });
+        target.dispatchEvent(event);
       }
       target.addEventListener('transitionend', hideTarget);
-      target.style.height = 0;
+      target.style.height = '0';
     });
   });
 };
@@ -47,7 +51,7 @@ export const slideUp = (target, duration = 500) => {
  * Slides target element down and into view.
  *
  * @name slideDown
- * @param {string} target - The element sliding down.
+ * @param {HTMLElement} target - The element sliding down.
  * @param {integer} duration - The duration of the animation, with default value 500.
  */
 export const slideDown = (target, duration = 500) => {
@@ -61,11 +65,11 @@ export const slideDown = (target, duration = 500) => {
     target.style.display = display;
     height = target.offsetHeight;
     target.style.overflow = 'hidden';
-    target.style.height = 0;
-    target.style.paddingTop = 0;
-    target.style.paddingBottom = 0;
-    target.style.marginTop = 0;
-    target.style.marginBottom = 0;
+    target.style.height = '0';
+    target.style.paddingTop = '0';
+    target.style.paddingBottom = '0';
+    target.style.marginTop = '0';
+    target.style.marginBottom = '0';
     target.style.boxSizing = 'border-box';
     target.style.transitionProperty = 'height, margin, padding';
     target.style.transitionDuration = `${duration}ms`;
@@ -81,6 +85,8 @@ export const slideDown = (target, duration = 500) => {
         target.style.removeProperty('transition-duration');
         target.style.removeProperty('transition-property');
         target.removeEventListener('transitionend', showTarget);
+        const event = new CustomEvent('finishslider', { detail: target });
+        target.dispatchEvent(event);
       }
       target.style.height = `${height}px`;
       target.addEventListener('transitionend', showTarget);
@@ -92,13 +98,21 @@ export const slideDown = (target, duration = 500) => {
  * Toggle slides target element in and out of view.
  *
  * @name slideToggle
- * @param {string} target - The element to toggle.
+ * @param {HTMLElement} target - The element to toggle.
  * @param {integer} duration - The duration of the animation, with default value 500.
  */
 export const slideToggle = (target, duration = 500) => {
-  if (window.getComputedStyle(target).display === 'none') {
-    return slideDown(target, duration);
-  } else {
-    return slideUp(target, duration);
+  if (!target.dataset.isSliding) {
+    target.addEventListener('finishslider', () => {
+      delete target.dataset.isSliding;
+      target.removeEventListener('finishslider');
+    });
+    if (window.getComputedStyle(target).display === 'none') {
+      target.dataset.isSliding = 'true';
+      slideDown(target, duration);
+    } else {
+      target.dataset.isSliding = 'true';
+      slideUp(target, duration);
+    }
   }
 };

--- a/js/src/modules/_slide.es6.js
+++ b/js/src/modules/_slide.es6.js
@@ -1,7 +1,7 @@
 /**
- * Use Notes: To unsure a seamless slide animation, the target element
- * should have both margins and paddings set to 0. You can customize
- * whitespace inside the target by adding paddings to any of the child
+ * Use Notes: To ensure a seamless slide animation, the target element
+ * should have both margin and padding set to 0. You can customize
+ * whitespace inside the target by adding padding to any of the child
  * elements.
  */
 
@@ -13,68 +13,79 @@
  * @param {integer} duration - The duration of the animation, with default value 500.
  */
 export const slideUp = (target, duration = 500) => {
-  target.style.transitionProperty = 'height, margin, padding';
-  target.style.transitionDuration = `${duration}ms`;
-  target.style.boxSizing = 'border-box';
   target.style.height = `${target.offsetHeight}px`;
-  target.style.overflow = 'hidden';
-  target.style.paddingTop = 0;
-  target.style.paddingBottom = 0;
-  target.style.marginTop = 0;
-  target.style.marginBottom = 0;
-  window.setTimeout(() => {
-    target.style.height = 0;
-  }, 10);
-  window.setTimeout(() => {
-    target.style.display = 'none';
-    target.style.removeProperty('height');
-    target.style.removeProperty('padding-top');
-    target.style.removeProperty('padding-bottom');
-    target.style.removeProperty('margin-top');
-    target.style.removeProperty('margin-bottom');
-    target.style.removeProperty('overflow');
-    target.style.removeProperty('transition-duration');
-    target.style.removeProperty('transition-property');
-  }, duration);
+  window.requestAnimationFrame(() => {
+    target.style.transitionProperty = 'height, margin, padding';
+    target.style.transitionDuration = `${duration}ms`;
+    target.style.boxSizing = 'border-box';
+    target.style.overflow = 'hidden';
+    target.style.paddingTop = 0;
+    target.style.paddingBottom = 0;
+    target.style.marginTop = 0;
+    target.style.marginBottom = 0;
+
+    window.requestAnimationFrame(() => {
+      function hideTarget() {
+        target.style.display = 'none';
+        target.style.removeProperty('height');
+        target.style.removeProperty('padding-top');
+        target.style.removeProperty('padding-bottom');
+        target.style.removeProperty('margin-top');
+        target.style.removeProperty('margin-bottom');
+        target.style.removeProperty('overflow');
+        target.style.removeProperty('transition-duration');
+        target.style.removeProperty('transition-property');
+        target.removeEventListener('transitionend', hideTarget);
+      }
+      target.addEventListener('transitionend', hideTarget);
+      target.style.height = 0;
+    });
+  });
 };
 
 /**
  * Slides target element down and into view.
  *
  * @name slideDown
- * @param {string} target - The element sliding doqn.
+ * @param {string} target - The element sliding down.
  * @param {integer} duration - The duration of the animation, with default value 500.
  */
 export const slideDown = (target, duration = 500) => {
+  let height;
   target.style.removeProperty('display');
-  let display = window.getComputedStyle(target).display;
-  if (display === 'none') {
-    display = 'block';
-  }
-  target.style.display = display;
-  const height = target.offsetHeight;
-  target.style.overflow = 'hidden';
-  target.style.height = 0;
-  target.style.paddingTop = 0;
-  target.style.paddingBottom = 0;
-  target.style.marginTop = 0;
-  target.style.marginBottom = 0;
-  target.style.boxSizing = 'border-box';
-  target.style.transitionProperty = 'height, margin, padding';
-  target.style.transitionDuration = `${duration}ms`;
-  target.style.removeProperty('padding-top');
-  target.style.removeProperty('padding-bottom');
-  target.style.removeProperty('margin-top');
-  target.style.removeProperty('margin-bottom');
-  window.setTimeout(() => {
-    target.style.height = `${height}px`;
-  }, 10);
-  window.setTimeout(() => {
-    target.style.removeProperty('height');
-    target.style.removeProperty('overflow');
-    target.style.removeProperty('transition-duration');
-    target.style.removeProperty('transition-property');
-  }, duration);
+  window.requestAnimationFrame(() => {
+    let display = window.getComputedStyle(target).display;
+    if (display === 'none') {
+      display = 'block';
+    }
+    target.style.display = display;
+    height = target.offsetHeight;
+    target.style.overflow = 'hidden';
+    target.style.height = 0;
+    target.style.paddingTop = 0;
+    target.style.paddingBottom = 0;
+    target.style.marginTop = 0;
+    target.style.marginBottom = 0;
+    target.style.boxSizing = 'border-box';
+    target.style.transitionProperty = 'height, margin, padding';
+    target.style.transitionDuration = `${duration}ms`;
+
+    window.requestAnimationFrame(() => {
+      function showTarget() {
+        target.style.removeProperty('padding-top');
+        target.style.removeProperty('padding-bottom');
+        target.style.removeProperty('margin-top');
+        target.style.removeProperty('margin-bottom');
+        target.style.removeProperty('height');
+        target.style.removeProperty('overflow');
+        target.style.removeProperty('transition-duration');
+        target.style.removeProperty('transition-property');
+        target.removeEventListener('transitionend', showTarget);
+      }
+      target.style.height = `${height}px`;
+      target.addEventListener('transitionend', showTarget);
+    });
+  });
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6688,8 +6688,7 @@
     "custom-event-polyfill": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==",
-      "dev": true
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
     },
     "cyclist": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "component": "node lib/component.js"
   },
   "dependencies": {
+    "custom-event-polyfill": "^1.0.7",
     "domready": "^1.0.8",
     "lightercollective": "^0.3.0"
   }


### PR DESCRIPTION
Closes #368 . This fixes an issue where, when slideToggle() was used, the target element sometimes just appeared or disappeared without the transition. It also modifies the script so that if you try to call slideToggle again before the previous toggle is finished, the call will be ignored. This is so that if you try to rapidly click on something that calls slideToggle, it won't start closing the slider before it's finished opening.

I went with the custom event route here instead of disabling the trigger button so that all of the functionality is contained within the script here. That makes the code here a bit more complicated but means that I could use it on Corey's test site without modifying anything outside of _slide.es6.js, so I think it'll be easier for other devs to drop into their projects this way.

@alecherryy , especially want your review on this one since you're most familiar with these scripts.