### PR TITLE
Update Gesso core requirements for Drupal 9

### DIFF
--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -2,7 +2,7 @@ name: Gesso
 type: theme
 description: 'Sass-based starter theme.'
 package: Core
-core: 8.x
+core_version_requirement: ^8.9 || ^9
 base theme: stable
 
 libraries:


### PR DESCRIPTION
Resolves #370 . Updates Gesso requirements to support Drupal 9. Note that this also requires the latest version of Drupal 8 for fresh installs.