### PR TITLE
Explicitly declare module dependencies

### DIFF
--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -4,6 +4,9 @@ description: 'Sass-based starter theme.'
 package: Core
 core_version_requirement: ^8.9 || ^9
 base theme: stable
+dependencies:
+  - components
+  - gesso_helper
 
 libraries:
   - gesso/global

--- a/gesso_helper/gesso_helper.info.yml
+++ b/gesso_helper/gesso_helper.info.yml
@@ -1,4 +1,4 @@
 name: Gesso Helper
 description: Provides additional functionality for the Gesso theme
 type: module
-core: '8.x'
+core_version_requirement: ^8.9 || ^9


### PR DESCRIPTION
Resolves #371. Requires Components! and Gesso Helper to be enabled before the Gesso theme can be installed.