### PR TITLE
Update Gesso Helper for Drush 10 

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,6 @@ The Gesso theme is maintained by [Dan Mouyard](https://drupal.org/u/dcmouyard)
 ([@shawnbrackat](http://twitter.com/shawnbrackat)),
 [Corey Lafferty](https://drupal.org/u/clafferty)
 ([@coreylafferty](http://twitter.com/coreylafferty)), and
-[Kelli Monahan](https://www.drupal.org/u/kmonahan).
+[KJ Monahan](https://www.drupal.org/u/kmonahan).
 
 Please use the Github issue queue: https://github.com/forumone/gesso/issues

--- a/gesso_helper/composer.json
+++ b/gesso_helper/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0"
+        "php": ">=7.3"
     },
     "extra": {
         "drush": {
             "services": {
-                "drush.services.yml": "^9"
+                "drush.services.yml": "^9.4.0 | ^10.0.0"
             }
         }
     }

--- a/gesso_helper/src/Commands/GessoHelperCommands.php
+++ b/gesso_helper/src/Commands/GessoHelperCommands.php
@@ -6,6 +6,7 @@ use Consolidation\SiteAlias\SiteAliasManagerAwareInterface;
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Drush;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\Filesystem\Filesystem;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -78,7 +79,9 @@ class GessoHelperCommands extends DrushCommands implements SiteAliasManagerAware
     $new_path = Path::join($theme_path, $machine_name);
 
     // Copy the Gesso theme directory recursively to the new theme’s location.
-    drush_op('drush_copy_dir', $gesso_path, $new_path);
+    $fs = new Filesystem();
+    $fs->mirror($gesso_path, $new_path);
+
 
     // Remove Gesso’s helper module from the new theme.
     $this->gesso_recursive_rm(Path::join($new_path, 'gesso_helper'));


### PR DESCRIPTION
Resolves #356 . Updates the Drush version requirements and replaces drush_copy_dir, which was deprecated in later versions of Drush 9 and removed in Drush 10.