### PR TITLE
Replace deprecated sameas test

### DIFF
--- a/source/_patterns/01-global/00-colors/_color-item.twig
+++ b/source/_patterns/01-global/00-colors/_color-item.twig
@@ -12,7 +12,7 @@
   <div class="pattern-lab-color-swatch__meta">
     <div class="pattern-lab-color-swatch__name">{{ name }}</div>
     <div class="pattern-lab-color-swatch__hex">
-      {% if color_value is sameas(color_label) %}
+      {% if color_value is same as(color_label) %}
         {{ color_value }}
       {% else %}
         {{ color_value }}


### PR DESCRIPTION
Resolves #379 . Replaces deprecated `sameas` with its replacement, `same as`.