### PR TITLE
Change default Pattern Lab verbosity

### DIFF
--- a/pattern-lab-config.json
+++ b/pattern-lab-config.json
@@ -34,7 +34,7 @@
       2600
     ]
   },
-  "logLevel": "info",
+  "logLevel": "warning",
   "outputFileSuffixes": {
     "rendered": ".rendered",
     "rawTemplate": "",


### PR DESCRIPTION
Changes the Pattern Lab log verbosity level so that it will output any warnings and errors but not the list of patterns built and other info-level messages.