### PR TITLE
Update fieldset classes to not remove required class

### DIFF
--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -1,11 +1,6 @@
-{% set removeClasses = [
-  'required',
-] %}
-
 {% set addClasses = [
   'fieldset',
   required ? 'is-required',
-  'js-form-wrapper',
 ] %}
 
 {% if type == 'fieldset' %}
@@ -16,7 +11,6 @@
   {% set removeClasses = removeClasses|merge([
     'fieldgroup',
     'form-composite',
-    'js-form-wrapper',
   ]) %}
   {% set addClasses = addClasses|merge([
     'fieldset--' ~ type|clean_class,


### PR DESCRIPTION
Fixes #391.

This PR also cleans up the logic of removing/adding the `js-form-wrapper` classes.