### PR TITLE
Update message component to always output message__content

### DIFF
--- a/source/_patterns/04-components/message/message.twig
+++ b/source/_patterns/04-components/message/message.twig
@@ -13,17 +13,16 @@
 {% endif %}
 
 <div {% if type == 'error' %} role="alert" {% else %} role="contentinfo" {% endif %} {% if heading %}aria-label="{{ heading }}"{% endif %} {{ add_attributes(additional_attributes) }}>
-  {% if messages|length > 1 %}
+  <div class="message__content">
     <h2 class="visually-hidden">{{ heading }}</h2>
-    <ul class="message__list">
-      {% for message in messages %}
-        <li class="message__item">{{- message -}}</li>
-      {% endfor %}
-    </ul>
-  {% else %}
-    <div class="message__content">
-      <h2 class="visually-hidden">{{ heading }}</h2>
+    {% if messages|length > 1 %}
+      <ul class="message__list">
+        {% for message in messages %}
+          <li class="message__item">{{- message -}}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
       {{- messages|first -}}
-    </div>
-  {% endif %}
+    {% endif %}
+  </div>
 </div>


### PR DESCRIPTION
The `message__content` should always be output, even if there are multiple messages. This new markup will fix the extra space at the bottom of lists in messages.