### PR TITLE
Fix false variable values for views-view component

### DIFF
--- a/source/_patterns/04-components/view/views-view/views-view.yml
+++ b/source/_patterns/04-components/view/views-view/views-view.yml
@@ -1,7 +1,7 @@
 ---
 element: 'div'
-title: 'false'
-header: 'false'
+title: false
+header: false
 exposed: false
 attachment_before: false
 rows: 'Rows'
@@ -11,5 +11,5 @@ attachment_after: false
 more: false
 footer: false
 feed_icons: false
-title_prefix: 'false'
-title_suffix: 'false'
+title_prefix: false
+title_suffix: false


### PR DESCRIPTION
Using `'false'` instead of `false` evaluates as `true` in Twig since it’s a valid string.