### PR TITLE
Update block templates

### DIFF
--- a/source/_patterns/04-components/block/_block.scss
+++ b/source/_patterns/04-components/block/_block.scss
@@ -5,7 +5,8 @@
   margin-bottom: rem(gesso-spacing(5));
 }
 
-// disable margin for layout builder blocks
+// Disable margin for admin and layout builder blocks.
+.block--admin,
 .block--provider-layout-builder {
   margin-bottom: 0;
 }

--- a/templates/block/block--local-tasks-block.html.twig
+++ b/templates/block/block--local-tasks-block.html.twig
@@ -1,7 +1,7 @@
 {#
  /**
   * @file
-  * Theme override to display system branding block.
+  * Theme override for the system branding block.
   *
   * Available variables:
   * - plugin_id: The ID of the block implementation.
@@ -25,14 +25,13 @@
 
 {% set classes = [
   'block',
-  'block--provider-' ~ configuration.provider|clean_class,
-  'block--id-' ~ plugin_id|clean_class,
+  'block--admin',
 ] %}
 
 {% set attributes = attributes.addClass(classes) %}
 
 {% embed '@components/block/block.twig' with {
-  'hide_wrapper': true,
+  'hide_wrapper': not logged_in,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false

--- a/templates/block/block--page-title-block.html.twig
+++ b/templates/block/block--page-title-block.html.twig
@@ -1,10 +1,10 @@
 {#
  /**
   * @file
-  * Theme override for page title block.
+  * Theme override for the page title block.
   */
 #}
 
 {% include '@components/page-title/page-title.twig' with {
-    'page_title': content['#title']
+  'page_title': content['#title'],
 } %}

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -1,7 +1,7 @@
 {#
  /**
   * @file
-  * Theme override to display system branding block.
+  * Theme override for the system branding block.
   *
   * Available variables:
   * - plugin_id: The ID of the block implementation.
@@ -25,14 +25,13 @@
 
 {% set classes = [
   'block',
-  'block--provider-' ~ configuration.provider|clean_class,
-  'block--id-' ~ plugin_id|clean_class,
+  'block--admin',
 ] %}
 
 {% set attributes = attributes.addClass(classes) %}
 
 {% embed '@components/block/block.twig' with {
-  'hide_wrapper': true,
+  'hide_wrapper': not logged_in,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false

--- a/templates/block/block--system-breadcrumb-block.html.twig
+++ b/templates/block/block--system-breadcrumb-block.html.twig
@@ -1,13 +1,19 @@
+{#
+ /**
+  * @file
+  * Theme override for the system breadcrumb block.
+  */
+#}
+
 {% set classes = [
   'block',
-  'block--provider-' ~ configuration.provider|clean_class,
-  'block--id-' ~ plugin_id|clean_class,
+  'block--admin',
 ] %}
 
 {% set attributes = attributes.addClass(classes) %}
 
 {% embed '@components/block/block.twig' with {
-  'hide_wrapper': true,
+  'hide_wrapper': not logged_in,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false

--- a/templates/block/block--system-main-block.html.twig
+++ b/templates/block/block--system-main-block.html.twig
@@ -1,13 +1,19 @@
+{#
+ /**
+  * @file
+  * Theme override for a system main block.
+  */
+#}
+
 {% set classes = [
   'block',
-  'block--provider-' ~ configuration.provider|clean_class,
-  'block--id-' ~ plugin_id|clean_class,
+  'block--admin',
 ] %}
 
 {% set attributes = attributes.addClass(classes) %}
 
 {% embed '@components/block/block.twig' with {
-  'hide_wrapper': true,
+  'hide_wrapper': not logged_in,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false

--- a/templates/block/block--system-menu-block--main.html.twig
+++ b/templates/block/block--system-menu-block--main.html.twig
@@ -1,9 +1,33 @@
-{% embed '@layouts/nav/nav.twig' with {
-  'label': 'Main Menu'
+{#
+ /**
+  * @file
+  * Theme override for the main menu block.
+  */
+#}
+
+{% set classes = [
+  'block--admin',
+] %}
+
+{% set attributes = attributes.addClass(classes) %}
+
+{% embed '@components/block/block.twig' with {
+  'hide_wrapper': not logged_in,
+  'has_constrain': false,
+  'hide_content_wrapper': true,
+  'label': false
 } %}
 
   {% block content %}
-    {{ content }}
+    {% embed '@layouts/nav/nav.twig' with {
+      'label': 'Main Menu'
+    } %}
+
+      {% block content %}
+        {{ content }}
+      {% endblock %}
+
+    {% endembed %}
   {% endblock %}
 
 {% endembed %}

--- a/templates/block/block--system-menu-block.html.twig
+++ b/templates/block/block--system-menu-block.html.twig
@@ -21,8 +21,14 @@
   */
 #}
 
+{% set classes = [
+  'block--admin',
+] %}
+
+{% set attributes = attributes.addClass(classes) %}
+
 {% embed '@components/block/block.twig' with {
-  'hide_wrapper': true,
+  'hide_wrapper': not logged_in,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false

--- a/templates/block/block.html.twig
+++ b/templates/block/block.html.twig
@@ -1,7 +1,7 @@
 {#
  /**
   * @file
-  * Theme override to display a block.
+  * Theme override for a block.
   *
   * Available variables:
   * - plugin_id: The ID of the block implementation.


### PR DESCRIPTION
This PR updates most block templates to output the wrapper if a user is logged in, so that contextual links will work. The bottom margin was also removed for `block--admin` variants so that they won’t mess up layouts for logged in users.