### PR TITLE
Refactor utility classes

### DIFF
--- a/source/_patterns/00-config/00-functions/_functions.numbers.scss
+++ b/source/_patterns/00-config/00-functions/_functions.numbers.scss
@@ -1,6 +1,6 @@
-/// Remove the unit of a length
-/// @param {Number} $number - Number to remove unit from
-/// @return {Number} - Unitless number
+// Remove the unit of a length
+// @param {Number} $number - Number to remove unit from
+// @return {Number} - Unitless number
 @function strip-unit($number) {
   @if type-of($number) == 'number' and not unitless($number) {
     @return $number / ($number * 0 + 1);
@@ -91,4 +91,20 @@
 
 @function is-number($value) {
   @return type-of($value) == 'number';
+}
+
+// Escape a decimal number (replaces . with -)
+@function escape-number($value) {
+  @if type-of($value) != 'number' {
+    @return $value;
+  }
+  $integer: floor(strip-unit($value));
+  $fraction: $value - $integer;
+  @if ($fraction == 0) {
+    @return $integer;
+  }
+  @while ($fraction != floor($fraction)) {
+    $fraction: $fraction * 10;
+  }
+  @return $integer + '-' + $fraction;
 }

--- a/source/_patterns/04-components/captioned-image/captioned-image.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image.twig
@@ -3,7 +3,7 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
-<figure class="{{ classes }}">
+<figure class="{{ classes }}"{% if caption %} role="group"{% endif %}>
   {{ media }}
   {% if caption %}
     <figcaption class="captioned-image__caption">{{ caption }}</figcaption>

--- a/source/_patterns/utility-classes/_accessibility.scss
+++ b/source/_patterns/utility-classes/_accessibility.scss
@@ -1,15 +1,12 @@
 // @file
-// Utility classes
-
-// Clearfix
-.clearfix {
-  @include clearfix-important;
-}
-
 // Accessibility utility classes
-.visually-hidden {
+
+.visually-hidden,
+.u-visually-hidden {
   @include visually-hidden-important;
-  &.focusable {
+
+  &.focusable,
+  &.u-focusable {
     &:focus,
     &:active {
       @include visually-hidden-off-important;
@@ -17,10 +14,12 @@
   }
 }
 
-.hidden {
+.hidden,
+.u-hidden {
   @include hidden-important;
 }
 
-.invisible {
+.invisible,
+.u-invisible {
   @include invisible-important;
 }

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -16,6 +16,14 @@
   }
 }
 
+.u-align-center {
+  margin-bottom: rem(gesso-get-map(gutter-width));
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: rem(gesso-get-map(gutter-width));
+  text-align: center;
+}
+
 // Clear floats
 .u-clear-both {
   clear: both;

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -16,14 +16,6 @@
   }
 }
 
-.u-align-center {
-  margin-bottom: rem(gesso-get-map(gutter-width));
-  margin-left: auto;
-  margin-right: auto;
-  margin-top: rem(gesso-get-map(gutter-width));
-  text-align: center;
-}
-
 // Clear floats
 .u-clear-both {
   clear: both;

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -2,18 +2,26 @@
 // Alignment utility classes
 
 // Align items
-.u-align-left {
+.u-align-left,
+.align-left {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: left;
     margin-right: rem(gesso-get-map(gutter-width));
   }
 }
 
-.u-align-right {
+.u-align-right,
+.align-right {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: right;
     margin-left: rem(gesso-get-map(gutter-width));
   }
+}
+
+.u-align-center,
+.align-center {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 // Clear floats

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -1,0 +1,30 @@
+// @file
+// Alignment utility classes
+
+// Align items
+.u-align-left {
+  @include breakpoint(gesso-breakpoint(tablet)) {
+    float: left;
+    margin-right: rem(gesso-get-map(gutter-width));
+  }
+}
+
+.u-align-right {
+  @include breakpoint(gesso-breakpoint(tablet)) {
+    float: right;
+    margin-left: rem(gesso-get-map(gutter-width));
+  }
+}
+
+// Clear floats
+.u-clear-both {
+  clear: both;
+}
+
+.u-clear-left {
+  clear: left;
+}
+
+.u-clear-right {
+  clear: right;
+}

--- a/source/_patterns/utility-classes/_clearfix.scss
+++ b/source/_patterns/utility-classes/_clearfix.scss
@@ -1,0 +1,7 @@
+// @file
+// Clearfix utility class
+
+.clearfix,
+.u-clearfix {
+  @include clearfix;
+}

--- a/source/_patterns/utility-classes/_full-width.scss
+++ b/source/_patterns/utility-classes/_full-width.scss
@@ -1,0 +1,11 @@
+// @file
+// Full-width utility class
+
+.u-full-width {
+  left: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  position: relative;
+  right: 50%;
+  width: 100vw;
+}

--- a/source/_patterns/utility-classes/_spaced.scss
+++ b/source/_patterns/utility-classes/_spaced.scss
@@ -1,0 +1,26 @@
+// @file
+// Utility classes for vertical spacing
+
+$sizes: 0.5, 1, 1.5, 2, 2.5, 3, 4, 5;
+
+@each $size in $sizes {
+  .u-spaced-#{escape-number($size)},
+  .u-spaced-#{escape-number($size)}-above {
+    margin-top: #{rem(gesso-spacing($size))} !important;
+  }
+
+  .u-spaced-#{escape-number($size)},
+  .u-spaced-#{escape-number($size)}-below {
+    margin-bottom: #{rem(gesso-spacing($size))} !important;
+  }
+}
+
+.u-spaced-none,
+.u-spaced-none-above {
+  margin-top: 0 !important;
+}
+
+.u-spaced-none,
+.u-spaced-none-below {
+  margin-bottom: 0 !important;
+}

--- a/source/styles.scss
+++ b/source/styles.scss
@@ -10,5 +10,5 @@ $pattern-lab-overrides: false !default;
 @import '_patterns/03-layouts/**/*.scss';
 @import '_patterns/04-components/**/*.scss';
 
-@import '_patterns/utility-classes';
+@import '_patterns/utility-classes/**/*.scss';
 @import '_patterns/shame';

--- a/templates/content-edit/filter-caption.html.twig
+++ b/templates/content-edit/filter-caption.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override for a filter caption.
+ *
+ * Returns HTML for a captioned image, audio, video or other tag.
+ *
+ * Available variables
+ * - string node: The complete HTML tag whose contents are being captioned.
+ * - string tag: The name of the HTML tag whose contents are being captioned.
+ * - string caption: The caption text.
+ * - string classes: The classes of the captioned HTML tag.
+ */
+#}
+{% set modifier_classes = [
+  classes ? classes
+]|join(' ')|trim %}
+
+{% include '@components/captioned-image/captioned-image.twig' with {
+  'modifier_classes': modifier_classes,
+  'media': node,
+  'caption': caption
+} %}


### PR DESCRIPTION
This PR:
* Adds a new `escape-number()` Sass function that will replace decimals in numbers with hyphens. This is useful if you want decimal numbers to work in class names.
* Breaks out classes in `_utility-classes.scss` into separate partials inside a new `utility-classes` folder
* Adds alignment utility classes (which would be useful to tackle #408)
* Adds full-width utility class, which will break elements outside of `l-constrain`
* Adds spaced utility classes, which allows one to easily add vertical spacing to a component without having to create new variants or states for each component
