### PR TITLE
added caption image template and tweaked utility styles

### DIFF
--- a/source/_patterns/04-components/captioned-image/captioned-image.twig
+++ b/source/_patterns/04-components/captioned-image/captioned-image.twig
@@ -3,7 +3,7 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
-<figure class="{{ classes }}">
+<figure class="{{ classes }}"{% if caption %} role="group"{% endif %}>
   {{ media }}
   {% if caption %}
     <figcaption class="captioned-image__caption">{{ caption }}</figcaption>

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -2,18 +2,29 @@
 // Alignment utility classes
 
 // Align items
-.u-align-left {
+.u-align-left,
+.align-left {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: left;
     margin-right: rem(gesso-get-map(gutter-width));
   }
 }
 
-.u-align-right {
+.u-align-right,
+.align-right {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: right;
     margin-left: rem(gesso-get-map(gutter-width));
   }
+}
+
+.u-align-center,
+.align-center {
+  margin-bottom: rem(gesso-get-map(gutter-width));
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: rem(gesso-get-map(gutter-width));
+  text-align: center;
 }
 
 // Clear floats

--- a/source/_patterns/utility-classes/_alignment.scss
+++ b/source/_patterns/utility-classes/_alignment.scss
@@ -20,11 +20,8 @@
 
 .u-align-center,
 .align-center {
-  margin-bottom: rem(gesso-get-map(gutter-width));
   margin-left: auto;
   margin-right: auto;
-  margin-top: rem(gesso-get-map(gutter-width));
-  text-align: center;
 }
 
 // Clear floats

--- a/templates/content-edit/filter-caption.html.twig
+++ b/templates/content-edit/filter-caption.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Theme override for a filter caption.
+ *
+ * Returns HTML for a captioned image, audio, video or other tag.
+ *
+ * Available variables
+ * - string node: The complete HTML tag whose contents are being captioned.
+ * - string tag: The name of the HTML tag whose contents are being captioned.
+ * - string caption: The caption text.
+ * - string classes: The classes of the captioned HTML tag.
+ */
+#}
+{% set modifier_classes = [
+  classes ? classes
+]|join(' ')|trim %}
+
+{% include '@components/captioned-image/captioned-image.twig' with {
+  'modifier_classes': modifier_classes,
+  'media': node,
+  'caption': caption
+} %}


### PR DESCRIPTION
- Added the classes that Drupal uses out of the box for alignment (e.g., if you add an image to the WYSIWYG): align-left, align-right, align-center
- Added a template for captioned images from the the WYSIWYG that makes use of our captioned-image component.  Added the role="group" property to this component if a caption is present.