### PR TITLE
updates readmore link arrow to not wrap on its own

### DIFF
--- a/source/_patterns/04-components/readmore-link/_readmore-link.scss
+++ b/source/_patterns/04-components/readmore-link/_readmore-link.scss
@@ -1,4 +1,5 @@
 .readmore-link {
+  padding-right: 28px;
   text-decoration: none;
   &:hover,
   &:focus {
@@ -10,11 +11,13 @@
 
 .readmore-link__icon {
   display: inline-block;
+  margin-right: -28px;
   position: relative;
   top: 8px;
   path {
     fill: gesso-color(text, link);
   }
+  width: 28px;
 }
 
 .readmore-link__accessibility-description {

--- a/source/_patterns/04-components/readmore-link/readmore-link.twig
+++ b/source/_patterns/04-components/readmore-link/readmore-link.twig
@@ -3,6 +3,7 @@
   modifier_classes ? modifier_classes,
 ]|join(' ')|trim %}
 
+{% spaceless %}
 <a href="{{ url }}" class="{{ classes }}">
   {{ label|default('Read more') }}
   <span class="readmore-link__icon">
@@ -10,8 +11,11 @@
       <path fill="#231f20" d="M14 4.648l9.352 9.352-9.352 9.352-1.641-1.641 6.508-6.563h-14.219v-2.297h14.219l-6.508-6.563z"></path>
     </svg>
   </span>
-  <span class="readmore-link__accessibility-description">
-    {{ description_prefix|default('about') }}
-    {{ title }}
-  </span>
+  {% if not hide_description %}
+    <span class="readmore-link__accessibility-description">
+      {{ description_prefix|default('about') }}
+      {{ title }}
+    </span>
+  {% endif %}
 </a>
+{% endspaceless %}


### PR DESCRIPTION
Also added the option to disable the accessibility description (for instances where you want to use this component, but may change the Read More text to something more descriptive).