### PR TITLE
updates components module namespace declarations

### DIFF
--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -58,19 +58,10 @@ regions:
   disabled: Disabled
   page_bottom: 'Page bottom'
 
-component-libraries:
-  base:
-    paths:
-      - source/_patterns/02-base
-  layouts:
-    paths:
-      - source/_patterns/03-layouts
-  components:
-    paths:
-      - source/_patterns/04-components
-  templates:
-    paths:
-      - source/_patterns/05-templates
-  macros:
-    paths:
-      - source/_macros
+components:
+  namespaces:
+    base: source/_patterns/02-base
+    layouts: source/_patterns/03-layouts
+    components: source/_patterns/04-components
+    templates: source/_patterns/05-templates
+    macros: source/_macros


### PR DESCRIPTION
Updates the namespace declarations for the Components module, per this alert showing in Drupal logs:  _"Components 8.x-1.x API is deprecated in components:8.x-2.0 and is removed from components:3.0.0. Update the gesso.info.yml file to replace the component-libraries.[namespace].paths data with components.namespaces.[namespace]."_

Related: https://www.drupal.org/docs/contributed-modules/components/registering-twig-namespaces