### PR TITLE
Address ESLint issues identified with Codacy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,7 @@ const compileStyles = () => {
       sass({
         includePaths: ['./node_modules/breakpoint-sass/stylesheets'],
         precision: 10,
-        importer: sassGlobImporter()
+        importer: sassGlobImporter(),
       })
     )
     .pipe(

--- a/source/_annotations/annotations.js
+++ b/source/_annotations/annotations.js
@@ -1,0 +1,9 @@
+var comments = {
+	"comments" : [
+		{
+			"el": "#annotation-css-selector",
+			"title" : "Annotation title",
+			"comment": "Annotation description"
+		}
+	]
+};

--- a/source/_annotations/annotations.js
+++ b/source/_annotations/annotations.js
@@ -1,9 +1,0 @@
-var comments = {
-	"comments" : [
-		{
-			"el": "#annotation-css-selector",
-			"title" : "Annotation title",
-			"comment": "Annotation description"
-		}
-	]
-};

--- a/source/_annotations/annotations.js
+++ b/source/_annotations/annotations.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 var comments = {
 	"comments" : [
 		{


### PR DESCRIPTION
Removes the placeholder annotations.js file but keeps the _annotations directory. I'm not sure whether we _need_ to keep the annotations directory, but it's consistent with how we're handling the _layouts directory.