### PR TITLE
Codacy local execution

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -8,6 +8,8 @@ engines:
     exclude_paths:
       - '**/*.svg'
       - '**/*.artifact.scss'
+  remark-lint:
+    enabled: false
 languages:
   php:
     extensions:

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,28 @@
+---
+engines:
+  phpcs:
+    enabled: true
+    php_version: 7.3
+  eslint:
+    enabled: true
+    exclude_paths:
+      - '**/*.svg'
+      - '**/*.artifact.scss'
+languages:
+  php:
+    extensions:
+      - '.php'
+      - '.module'
+      - '.inc'
+      - '.install'
+      - '.profile'
+      - '.theme'
+      - '.test'
+exclude_paths:
+  - 'pattern-lab/**'
+  - 'css/**'
+  - 'js/dist/**'
+  - 'js/libraries/**'
+  - 'js/overrides/**'
+  - 'node_modules/**'
+  - 'lib/**'

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -23,8 +23,10 @@ languages:
 exclude_paths:
   - 'pattern-lab/**'
   - 'css/**'
+  - 'images/**'
   - 'js/dist/**'
   - 'js/libraries/**'
   - 'js/overrides/**'
   - 'node_modules/**'
+  - 'vendor/**'
   - 'lib/**'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
     node: true,
     browser: true,
   },
-  plugins: ['implicit-dependencies'],
+  plugins: [],
   extends: ['eslint:recommended', 'plugin:prettier/recommended'],
   rules: {
     'arrow-parens': ['off', 'as-needed'],
@@ -23,10 +23,6 @@ module.exports = {
     'dot-notation': 'error',
     eqeqeq: 'error',
     'guard-for-in': 'error',
-    'implicit-dependencies/no-implicit': [
-      'error',
-      { optional: true, dev: true },
-    ],
     'no-console': 'error',
     'no-empty-function': 'error',
     'no-floating-decimal': 'error',

--- a/docker-compose.cli.yml
+++ b/docker-compose.cli.yml
@@ -1,0 +1,12 @@
+# This is the Docker Compose entry point for this project.
+# Services listed in this file will automatically be built and started when you bring
+# the project up.
+#
+# Note: This file adds no additional configuration, but it is present to support
+#   execution with the `forumone/forumone-cli` utility in the format of
+#   `f1 run <service>`.
+version: "3.7"
+services:
+  {}
+volumes:
+  {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,12 @@ services:
     <<: *codacy
     entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t eslint
     command: ''
-    
+
   # Run StyleLint linting with `docker-compose run stylelint`.
   stylelint:
     <<: *codacy
     entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t stylelint
     command: ''
+volumes:
+  ? gesso-pattern-lab
+  ? gesso-css

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,18 @@
 version: "3.7"
 services:
   gesso:
-    build: .
+    build: ./
+    init: true
     volumes:
-      - "$PWD:/"
+      - ./images:/app/images:cached
+      - ./js:/app/js:cached
+      - ./source:/app/source:cached
+      - type: volume
+        source: gesso-pattern-lab
+        target: /app/pattern-lab
+      - type: volume
+        source: gesso-css
+        target: /app/css
 
   # Run all scans with `docker-compose run codacy`.
   # Target a specific tool with `docker-compose run codacy analyze -t <tool>`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     working_dir: "${PWD}"
     command: analyze
     volumes:
-      - "$PWD:$PWD"
+      - ${PWD}:${PWD}:cached
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# This is the Compose file for command-line services.
+# Anything that doesn't need to be run as part of the main `docker-compose up'
+# command should reside in here and be invoked by a helper script.
 version: "3.7"
 services:
   gesso:
@@ -14,8 +17,9 @@ services:
         source: gesso-css
         target: /app/css
 
-  # Run all scans with `docker-compose run codacy`.
+  # Run all scans with `docker-compose run codacy` or `f1 run codacy`.
   # Target a specific tool with `docker-compose run codacy analyze -t <tool>`
+  # or `f1 run codacy analyze -t <tool>`.
   codacy: &codacy
     image: codacy/codacy-analysis-cli:latest
     environment:
@@ -27,23 +31,24 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /tmp:/tmp
 
-  # Run PHPCS linting with `docker-compose run phpcs`.
+  # Run PHPCS linting with `docker-compose run phpcs` or `f1 run phpcs`.
   phpcs:
     <<: *codacy
     entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t phpcs
     command: ''
 
-  # Run ESLint linting with `docker-compose run eslint`.
+  # Run ESLint linting with `docker-compose run eslint` or `f1 run eslint`.
   eslint:
     <<: *codacy
     entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t eslint
     command: ''
 
-  # Run StyleLint linting with `docker-compose run stylelint`.
+  # Run StyleLint linting with `docker-compose run stylelint` or `f1 run stylelint`.
   stylelint:
     <<: *codacy
     entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t stylelint
     command: ''
+
 volumes:
   ? gesso-pattern-lab
   ? gesso-css

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.7"
+services:
+  gesso:
+    build: .
+    volumes:
+      - "$PWD:/"
+
+  # Run all scans with `docker-compose run codacy`.
+  # Target a specific tool with `docker-compose run codacy analyze -t <tool>`
+  codacy: &codacy
+    image: codacy/codacy-analysis-cli:latest
+    environment:
+      CODACY_CODE: "${PWD}"
+    working_dir: "${PWD}"
+    command: analyze
+    volumes:
+      - "$PWD:$PWD"
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp
+
+  # Run PHPCS linting with `docker-compose run phpcs`.
+  phpcs:
+    <<: *codacy
+    entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t phpcs
+    command: ''
+
+  # Run ESLint linting with `docker-compose run eslint`.
+  eslint:
+    <<: *codacy
+    entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t eslint
+    command: ''
+    
+  # Run StyleLint linting with `docker-compose run stylelint`.
+  stylelint:
+    <<: *codacy
+    entrypoint: /opt/codacy/bin/codacy-analysis-cli analyze -t stylelint
+    command: ''

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset name="gesso_theme">
+  <description>PHP_CodeSniffer standards for the Gesso Drupal theme.</description>
+
+  <!-- Use default Drupal coding standards. -->
+  <rule ref="Drupal" />
+  <rule ref="DrupalPractice" />
+
+  <!-- Scan within this directory. -->
+  <file>.</file>
+
+  <exclude-pattern>vendor/*</exclude-pattern>
+  <exclude-pattern>node_modules/*</exclude-pattern>
+  <exclude-pattern>css/*</exclude-pattern>
+  <exclude-pattern>js/dist/*</exclude-pattern>
+  <exclude-pattern>js/libraries/*</exclude-pattern>
+  <exclude-pattern>js/overrides/*</exclude-pattern>
+  <exclude-pattern>lib/*</exclude-pattern>
+  <exclude-pattern>**/*.min.js</exclude-pattern>
+  <exclude-pattern>pattern-lab/*</exclude-pattern>
+
+</ruleset>
+


### PR DESCRIPTION
This PR builds on top of #441 to support local execution of the [Codacy CLI](https://github.com/codacy/codacy-analysis-cli) for scanning outside of the PR process.

- [x] Add docker-compose configuration to run the Codacy CLI
- [x] Add common tool shortcuts for Codacy CLI execution
- [ ] Add README documentation about the role of Codacy and usage

### Local Execution

Codacy may be executed locally using the provided Docker Compose configuration as documented in the `docker-compose.yml` file.

#### PHPCS

```bash
docker-compose run phpcs
```

#### ESLint

```bash
docker-compose run eslint
```

#### Codacy

Review of all available Codacy CLI usage may be accomplished with:

```bash
docker-compose run codacy --help
```

All scanners may be completed using the following (An output file is recommended due to the amount of output.):

```bash
docker-compose run codacy analyze -o quality.txt
```

[A specific tool](https://docs.codacy.com/repositories-configure/codacy-configuration-file/#which-tools-can-be-configured-and-which-name-should-i-use), aside from the pre-configured ones noted above, may be executed using:

```bash
docker-compose run codacy analyze -t <tool>
```