### PR TITLE
Add Pattern Lab READMEs

### DIFF
--- a/source/_annotations/README.md
+++ b/source/_annotations/README.md
@@ -1,0 +1,6 @@
+# Annotations
+
+Annotations on patterns.
+
+## Documentation
+Annotations can be in YAML or JSON. [See Pattern Lab documentation on adding annotations](https://patternlab.io/docs/adding-annotations/)

--- a/source/_annotations/annotations.js
+++ b/source/_annotations/annotations.js
@@ -1,9 +1,0 @@
-var comments = {
-	"comments" : [
-		{
-			"el": "#annotation-css-selector",
-			"title" : "Annotation title",
-			"comment": "Annotation description"
-		}
-	]
-};

--- a/source/_data/README.md
+++ b/source/_data/README.md
@@ -1,0 +1,8 @@
+# Data
+
+Placeholder data available for use in patterns.
+
+## Documentation
+[Overview of data](https://patternlab.io/docs/overview-of-data/)
+
+Data can be in YAML files or in [JSON](https://patternlab.io/docs/introduction-to-json-and-mustache-variables/).

--- a/source/_layouts/.gitkeep
+++ b/source/_layouts/.gitkeep
@@ -1,1 +1,0 @@
-keeping this directory

--- a/source/_macros/.gitkeep
+++ b/source/_macros/.gitkeep
@@ -1,1 +1,0 @@
-keeping this directory

--- a/source/_macros/README.md
+++ b/source/_macros/README.md
@@ -1,0 +1,13 @@
+# Macros
+
+Twig macros.
+
+## Documentation
+[Twig documentation on macros](https://twig.symfony.com/doc/2.x/tags/macro.html)
+
+Macros can be imported into pattern files using the namespace `@macros`.
+Example:
+```
+{% import '@macros/gesso.macro.twig' as macros %}
+{% set nav_content = macros.sample_content('Nav Layout Content') %}
+```

--- a/source/_meta/README.md
+++ b/source/_meta/README.md
@@ -1,0 +1,7 @@
+# Meta
+
+Pattern lab header and footer. Any new CSS and JS files need to be added here
+to be included in the pattern lab display.
+
+## Documentation
+[Modifying the Pattern Header & Footer](https://patternlab.io/docs/modifying-the-pattern-header-and-footer/)

--- a/source/_patterns/README.md
+++ b/source/_patterns/README.md
@@ -1,0 +1,11 @@
+# Patterns
+
+UI patterns, written in Twig.
+
+## Documentation
+[Overview of Patterns](https://patternlab.io/docs/overview-of-patterns/)
+
+Each pattern should include a Markdown file with the selector, title, and any
+variables and/or blocks used. More about [documentating patterns](https://patternlab.io/docs/documenting-patterns/).
+
+Patterns can also include [pattern-specific data](https://patternlab.io/docs/creating-pattern-specific-values/).

--- a/source/_twig-components/README.md
+++ b/source/_twig-components/README.md
@@ -1,0 +1,12 @@
+# Twig Components
+
+Custom Twig filters and functions.
+
+## Documentation
+[Example of custom Twig functions](https://github.com/pattern-lab/patternlab-node/blob/dev/packages/edition-twig/alter-twig.php)
+
+New files need to be added to pattern-lab-config.json. [Example](https://github.com/pattern-lab/patternlab-node/blob/dev/packages/edition-twig/patternlab-config.json#L48-L56)
+
+Any filters and functions shared with Drupal also need to be added to the [Gesso Helper module](../../gesso_helper/src/TwigExtension/GessoExtensionLoader.php).
+
+For more about extending Twig, see the [Twig documentation](https://twig.symfony.com/doc/2.x/advanced.html) and [Drupal examples](https://api.drupal.org/api/drupal/core%21modules%21system%21tests%21modules%21twig_extension_test%21src%21TwigExtension%21TestExtension.php/9).


### PR DESCRIPTION
Also deletes the placeholder annotations.js file and deletes the _layouts directory. As best I can tell from reviewing Gesso code and the Pattern Lab docs, the _layouts directory isn't used for anything anymore, but if anyone knows otherwise, let me know.