### PR TITLE
Update browserslist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,12 +345,6 @@
             "node-releases": "^1.1.70"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001205",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-          "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==",
-          "dev": true
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -3265,12 +3259,6 @@
             "map-obj": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001205",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-          "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==",
-          "dev": true
-        },
         "chownr": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -4930,12 +4918,6 @@
             "node-releases": "^1.1.70"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001205",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001205.tgz",
-          "integrity": "sha512-TL1GrS5V6LElbitPazidkBMD9sa448bQDDLrumDqaggmKFcuU2JW1wTOHJPukAcOMtEmLcmDJEzfRrf+GjM0Og==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.10.0.tgz",
@@ -5132,6 +5114,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "1.2.3",
@@ -5684,9 +5676,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001113",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001113.tgz",
-      "integrity": "sha512-qMvjHiKH21zzM/VDZr6oosO6Ri3U0V2tC015jRXjOecwQCJtsU5zklTNTk31jQbIOP8gha0h1ccM/g0ECP+4BA==",
+      "version": "1.0.30001223",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz",
+      "integrity": "sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -9125,6 +9117,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filesize": {
       "version": "3.6.1",
@@ -22847,6 +22846,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
     "node": ">=10"
   },
   "browserslist": [
-    "explorer >= 11",
-    "last 3 versions",
-    ">1% and not dead"
+    "last 2 versions and not dead",
+    ">= 1%"
   ],
   "devDependencies": {
     "@babel/core": "^7.11.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "browserslist": [
     "last 2 versions and not dead",
-    ">= 1%"
+    ">= 1%",
+    ">= 1% in US"
   ],
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
Runs `npx browserslist@latest --update-db` to update package-lock.json with the latest caniuse-lite version (as described in https://github.com/browserslist/browserslist#browsers-data-updating, we have to do this periodically) and adjusts the default browserslist settings so as not to target IE 11 specifically.

Instead, I changed the logic to include:
* The last two versions of any browser that isn't dead (changed from 3 to 2 because we typically promise support of last 2 versions in our SOW and QA plans) OR
* Any browser with at least 1% global usage OR
* Any browser with at least 1% US usage

Running `npx browserslist` shows you the current list of browsers this targets. It includes IE11 (not officially dead yet, alas) and iOS Safari 13, which is more than 2 versions old but still has at least 1% US usage. In practice, this doesn't change much about the browsers being targeted, but it removes some older versions of browsers (Firefox 86, for example) with minimal usage and ensures that once IE11 is officially dead and below 1% usage, Babel won't be adding polyfills for it.