### PR TITLE
Separate development and build/production linting rules

### DIFF
--- a/.eslintrc-dev.js
+++ b/.eslintrc-dev.js
@@ -1,0 +1,9 @@
+module.exports = {
+  extends: '.eslintrc.js',
+  rules: {
+    'no-console': 'off',
+    'no-empty-function': 'off',
+    'no-unused-vars': 'off',
+    'prefer-const': 'off',
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
       'error',
       { optional: true, dev: true },
     ],
-    'no-console': 'error',
+    'no-console': ['error', { allow: ['warn', 'error'] }],
     'no-empty-function': 'error',
     'no-floating-decimal': 'error',
     'no-irregular-whitespace': 'off',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,9 @@ module.exports = mode => {
             {
               loader: 'eslint-loader',
               options: {
-                configFile: path.resolve(__dirname, '.eslintrc.js'),
+                configFile: isDevelopment
+                  ? path.resolve(__dirname, '.eslintrc-dev.js')
+                  : path.resolve(__dirname, '.eslintrc.js'),
               },
             },
           ],


### PR DESCRIPTION
Adds a new ESLint config file, `.eslintrc-dev.js` that extends the standard `eslintrc.js` config and overrides specific rules. This config file is used when webpack is in development mode (i.e. when you're running `f1 run gesso gulp`) to account for things that can be useful while working on a feature but should be removed before merging.

I also changed the base ESLint config to allow `console.warn()` and `console.error()`, though not other uses of console.

**To Test Locally**
Run `f1 run gesso gulp build` instead of `f1 run gesso gulp`.

**To Test in a PR**
If Buildkite is building for all branches and on PR creation, builds will fail if ESLint fails, which will show up as a status check in the PR. Since Codacy also runs ESLint using the base ESLint config file, it should also catch any lingering linting issues once it's fully setup and integrated on projects.

**Rules Disabled on Dev**
`no-console`: So you can `console.log` to your heart's content while debugging
`no-empty-function`: Allow for stubbing functions and methods initially
`no-unused-vars` and `prefer-const`: Allow for testing before all code is written and/or commenting out or removing chunks of code while debugging. This allows you to (temporarily) have variables that don't get used and/or variables defined with `let` that don't have their values changed.