### PR TITLE
created new breakpoint mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,14 +308,17 @@ CSS and JavaScript, you should use simple strings or numbers.
 ### Width Based Media Queries
 
 Gesso uses custom mixins to specify viewport width based media queries:
-`breakpoint`, `breakpoint-max` and `breakpoint-min-max` for min-width,
-max-width or a combination of both, respectively. Each mixin takes one or two
+* `breakpoint`: min-width queries
+* `breakpoint-max`: max-width queries
+* `breakpoint-min-max`: queries with both a min and max width
+
+Each mixin takes one or two
 width parameters, which can be a straight value (e.g., 800px, 40em) or a design
 token value called using the `gesso-breakpoint` function (e.g.,
 `gesso-breakpoint(tablet-lg)`).  The `breakpoint-max` and `breakpoint-min-max`
-mixins can also take an optional parameter to subtrax one pixel from the
-max-width value, which can be useful when using the Gesso breakpoint token
-values.
+mixins can also take an optional parameter to subtract one pixel from the
+max-width value, which can be useful when you want your query to go up to the
+value but not to include it, such as when using Gesso breakpoint token values.
 
 **`@include breakpoint($width) { // styles }`
 Output a min-width based media query.**

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ examples:
   display: flex;
 }
 
-@include breakpoint-max(gesso-breakpoint(mobile)) {
+@include breakpoint-max(gesso-breakpoint(mobile), true) {
   display: none;
 }
 
-@include breakpoint-min-max(gesso-breakpoint(mobile), gesso-breakpoint(tablet)) {
+@include breakpoint-min-max(gesso-breakpoint(mobile), gesso-breakpoint(tablet), true) {
   display: block;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -305,6 +305,68 @@ value, if available. If there is no fallback value, the token will be omitted
 from the JavaScript objects. In general, if you want to share a value between
 CSS and JavaScript, you should use simple strings or numbers.
 
+### Width Based Media Queries
+
+Gesso uses custom mixins to specify viewport width based media queries:
+`breakpoint`, `breakpoint-max` and `breakpoint-min-max` for min-width,
+max-width or a combination of both, respectively. Each mixin takes one or two
+width parameters, which can be a straight value (e.g., 800px, 40em) or a design
+token value called using the `gesso-breakpoint` function (e.g.,
+`gesso-breakpoint(tablet-lg)`).  The `breakpoint-max` and `breakpoint-min-max`
+mixins can also take an optional parameter to subtrax one pixel from the
+max-width value, which can be useful when using the Gesso breakpoint token
+values.
+
+**`@include breakpoint($width) { // styles }`
+Output a min-width based media query.**
+
+examples:
+
+```
+@include breakpoint(gesso-breakpoint(800px)) {
+  display: flex;
+}
+
+@include breakpoint(gesso-breakpoint(desktop)) {
+  display: none;
+}
+```
+
+**`@include breakpoint-max($width, $subtract_1_from_max) { // styles }`
+Output a max-width based media query. The optional $subtract_1_from_max
+parameter will subtract 1px from the width value if set to `true`
+(default: `false`).**
+
+examples:
+
+```
+@include breakpoint-max(900px) {
+  display: block;
+}
+
+@include breakpoint-max(gesso-breakpoint(mobile), true) {
+  display: none;
+}
+```
+
+**`@include breakpoint-min-max($min-width, $max-width, $subtract_1_from_max)
+{ // styles }`
+Output a media query with both a min-width and max-width. The optional
+$subtract_1_from_max parameter will subtract 1px from the max-width value if
+set to `true` (default: `false`).**
+
+examples:
+
+```
+@include breakpoint-min-max(400px, 700px) {
+  display: flex;
+}
+
+@include breakpoint-min-max(gesso-breakpoint(mobile), gesso-breakpoint(tablet), true) {
+  display: block;
+}
+```
+
 ### Creating New Components
 
 Gesso includes a script to generate new component files. To use, run the

--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ examples:
   display: flex;
 }
 
-@include breakpoint(gesso-breakpoint(mobile), 'max') {
+@include breakpoint-max(gesso-breakpoint(mobile)) {
   display: none;
 }
 
-@media (min-width: #{em(gesso-breakpoint(mobile))}) and (max-width: #{em(gesso-breakpoint(tablet))}) {
+@include breakpoint-min-max(gesso-breakpoint(mobile), gesso-breakpoint(tablet)) {
   display: block;
 }
 ```

--- a/source/_patterns/00-config/00-functions/_functions.numbers.scss
+++ b/source/_patterns/00-config/00-functions/_functions.numbers.scss
@@ -1,11 +1,11 @@
+@use "sass:math";
 // Remove the unit of a length
 // @param {Number} $number - Number to remove unit from
 // @return {Number} - Unitless number
 @function strip-unit($number) {
   @if type-of($number) == 'number' and not unitless($number) {
-    @return $number / ($number * 0 + 1);
+    @return math.div($number, ($number * 0 + 1));
   }
-
   @return $number;
 }
 

--- a/source/_patterns/00-config/00-functions/_functions.unit-convert.scss
+++ b/source/_patterns/00-config/00-functions/_functions.unit-convert.scss
@@ -30,7 +30,11 @@
   @if (type-of($base) != 'number' or unit($base) != 'px') {
     @error "Base font size must be in pixels.";
   }
-  @return strip-unit($value) * $base;
+  @if (unit($value) != 'px') {
+    @return strip-unit($value) * $base;
+  } @else {
+    @return $value;
+  }
 }
 
 /// Convert values to em.

--- a/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
@@ -1,10 +1,42 @@
+// @file
+// Breakpoint mixins
+
 @use "sass:string";
 
-@mixin breakpoint($breakpoint, $width-type: 'min') {
+// Create a min-width media query
+@mixin breakpoint-min($breakpoint) {
   @if $breakpoints-ems {
     $breakpoint: em($breakpoint);
   }
-  @media (#{string.to-lower-case($width-type)}-width: #{$breakpoint}) {
+  @media (min-width: #{$breakpoint}) {
+    @content;
+  }
+}
+
+// Assume min-width if you use shorthand breakpoint mixin
+@mixin breakpoint($breakpoint) {
+  @include breakpoint-min($breakpoint) {
+    @content;
+  }
+}
+
+// Create a max-width media query
+@mixin breakpoint-max($breakpoint) {
+  @if $breakpoints-ems {
+    $breakpoint: em($breakpoint);
+  }
+  @media (max-width: #{$breakpoint}) {
+    @content;
+  }
+}
+
+// Create a media query with both min-width and max-width
+@mixin breakpoint-min-max($breakpoint-min, $breakpoint-max) {
+  @if $breakpoints-ems {
+    $breakpoint-min: em($breakpoint-min);
+    $breakpoint-max: em($breakpoint-max);
+  }
+  @media (min-width: #{$breakpoint-min}) and (max-width: #{$breakpoint-max}) {
     @content;
   }
 }

--- a/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
@@ -4,6 +4,7 @@
 @use "sass:string";
 
 // Create a min-width media query.
+// @param {Number} $breakpoint - width value.
 @mixin breakpoint-min($breakpoint) {
   @if $breakpoints-ems {
     $breakpoint: em($breakpoint);
@@ -14,6 +15,7 @@
 }
 
 // Assume min-width if shorthand breakpoint mixin is used.
+// @param {Number} $breakpoint - width value.
 @mixin breakpoint($breakpoint) {
   @include breakpoint-min($breakpoint) {
     @content;
@@ -21,7 +23,12 @@
 }
 
 // Create a max-width media query.
-@mixin breakpoint-max($breakpoint) {
+// @param {Number} $breakpoint - width value.
+// @param {Boolean} $subtract_1_from_max - whether to subtract 1px from $breakpoint value.
+@mixin breakpoint-max($breakpoint, $subtract_1_from_max: false) {
+  @if $subtract_1_from_max {
+    $breakpoint: px($breakpoint) - 1px;
+  }
   @if $breakpoints-ems {
     $breakpoint: em($breakpoint);
   }
@@ -31,7 +38,17 @@
 }
 
 // Create a media query with both min-width and max-width.
-@mixin breakpoint-min-max($breakpoint-min, $breakpoint-max) {
+// @param {Number} $breakpoint-min - width value.
+// @param {Number} $breakpoint-max - width value.
+// @param {Boolean} $subtract_1_from_max - whether to subtract 1px from $breakpoint-max value.
+@mixin breakpoint-min-max(
+  $breakpoint-min,
+  $breakpoint-max,
+  $subtract_1_from_max: false
+) {
+  @if $subtract_1_from_max {
+    $breakpoint-max: px($breakpoint-max) - 1px;
+  }
   @if $breakpoints-ems {
     $breakpoint-min: em($breakpoint-min);
     $breakpoint-max: em($breakpoint-max);

--- a/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
@@ -3,7 +3,7 @@
 
 @use "sass:string";
 
-// Create a min-width media query
+// Create a min-width media query.
 @mixin breakpoint-min($breakpoint) {
   @if $breakpoints-ems {
     $breakpoint: em($breakpoint);
@@ -13,14 +13,14 @@
   }
 }
 
-// Assume min-width if you use shorthand breakpoint mixin
+// Assume min-width if shorthand breakpoint mixin is used.
 @mixin breakpoint($breakpoint) {
   @include breakpoint-min($breakpoint) {
     @content;
   }
 }
 
-// Create a max-width media query
+// Create a max-width media query.
 @mixin breakpoint-max($breakpoint) {
   @if $breakpoints-ems {
     $breakpoint: em($breakpoint);

--- a/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
+++ b/source/_patterns/00-config/01-mixins/_mixins.breakpoint.scss
@@ -30,7 +30,7 @@
   }
 }
 
-// Create a media query with both min-width and max-width
+// Create a media query with both min-width and max-width.
 @mixin breakpoint-min-max($breakpoint-min, $breakpoint-max) {
   @if $breakpoints-ems {
     $breakpoint-min: em($breakpoint-min);

--- a/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
+++ b/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
@@ -30,7 +30,7 @@ h1,
   @extend %hN;
   @include display-text-style(h1);
 
-  @include breakpoint-max(gesso-breakpoint(tablet)) {
+  @include breakpoint-max(gesso-breakpoint(tablet), true) {
     font-size: rem(gesso-font-size(5));
   }
 }
@@ -40,7 +40,7 @@ h2,
   @extend %hN;
   @include display-text-style(h2);
 
-  @include breakpoint-max(gesso-breakpoint(tablet)) {
+  @include breakpoint-max(gesso-breakpoint(tablet), true) {
     font-size: rem(gesso-font-size(4));
   }
 }
@@ -50,7 +50,7 @@ h3,
   @extend %hN;
   @include display-text-style(h3);
 
-  @include breakpoint-max(gesso-breakpoint(tablet)) {
+  @include breakpoint-max(gesso-breakpoint(tablet), true) {
     font-size: rem(gesso-font-size(3));
   }
 }
@@ -60,7 +60,7 @@ h4,
   @extend %hN;
   @include display-text-style(h4);
 
-  @include breakpoint-max(gesso-breakpoint(tablet)) {
+  @include breakpoint-max(gesso-breakpoint(tablet), true) {
     font-size: rem(gesso-font-size(2));
   }
 }

--- a/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
+++ b/source/_patterns/02-base/02-html-elements/13-headings/_headings.scss
@@ -30,7 +30,7 @@ h1,
   @extend %hN;
   @include display-text-style(h1);
 
-  @include breakpoint(gesso-breakpoint(tablet), 'max') {
+  @include breakpoint-max(gesso-breakpoint(tablet)) {
     font-size: rem(gesso-font-size(5));
   }
 }
@@ -40,7 +40,7 @@ h2,
   @extend %hN;
   @include display-text-style(h2);
 
-  @include breakpoint(gesso-breakpoint(tablet), 'max') {
+  @include breakpoint-max(gesso-breakpoint(tablet)) {
     font-size: rem(gesso-font-size(4));
   }
 }
@@ -50,7 +50,7 @@ h3,
   @extend %hN;
   @include display-text-style(h3);
 
-  @include breakpoint(gesso-breakpoint(tablet), 'max') {
+  @include breakpoint-max(gesso-breakpoint(tablet)) {
     font-size: rem(gesso-font-size(3));
   }
 }
@@ -60,7 +60,7 @@ h4,
   @extend %hN;
   @include display-text-style(h4);
 
-  @include breakpoint(gesso-breakpoint(tablet), 'max') {
+  @include breakpoint-max(gesso-breakpoint(tablet)) {
     font-size: rem(gesso-font-size(2));
   }
 }

--- a/source/_patterns/03-layouts/grid/_grid.scss
+++ b/source/_patterns/03-layouts/grid/_grid.scss
@@ -54,7 +54,7 @@ $grid-gutter: gesso-get-map(gutter-width);
     @include css-fixed-grid(1);
   }
 
-  @media (min-width: #{em(600px)}) and (max-width: #{em(800px)}) {
+  @include breakpoint-min-max(600px, 800px) {
     > * {
       @include set-flex-column(2, $grid-gutter, 275px);
     }
@@ -82,7 +82,7 @@ $grid-gutter: gesso-get-map(gutter-width);
     @include css-fixed-grid(1);
   }
 
-  @media (min-width: #{em(600px)}) and (max-width: #{em(999px)}) {
+  @include breakpoint-min-max(600px, 999px) {
     > * {
       @include set-flex-column(3, $grid-gutter, 0);
     }

--- a/source/_patterns/04-components/breadcrumb/_breadcrumb.scss
+++ b/source/_patterns/04-components/breadcrumb/_breadcrumb.scss
@@ -42,7 +42,7 @@ $breadcrumb-text-color: gesso-color(text, on-dark) !default;
 }
 
 .breadcrumb__list .breadcrumb__item {
-  @include breakpoint(gesso-breakpoint(tablet), 'max') {
+  @include breakpoint-max(gesso-breakpoint(tablet)) {
     display: none;
 
     &:nth-last-child(2) {

--- a/source/_patterns/04-components/breadcrumb/_breadcrumb.scss
+++ b/source/_patterns/04-components/breadcrumb/_breadcrumb.scss
@@ -42,7 +42,7 @@ $breadcrumb-text-color: gesso-color(text, on-dark) !default;
 }
 
 .breadcrumb__list .breadcrumb__item {
-  @include breakpoint-max(gesso-breakpoint(tablet)) {
+  @include breakpoint-max(gesso-breakpoint(tablet), true) {
     display: none;
 
     &:nth-last-child(2) {

--- a/source/_patterns/04-components/hero-bg-image/_hero-bg-image.scss
+++ b/source/_patterns/04-components/hero-bg-image/_hero-bg-image.scss
@@ -36,7 +36,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   color: gesso-color(text, on-dark);
   margin-bottom: rem(gesso-spacing(5));
 
-  @include breakpoint-max($hero-bg-image-bp) {
+  @include breakpoint-max($hero-bg-image-bp, true) {
     font-size: rem(gesso-font-size(7));
     margin-bottom: rem(gesso-spacing(3));
   }
@@ -47,7 +47,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   color: gesso-color(text, on-dark);
   margin-bottom: rem(gesso-spacing(5));
 
-  @include breakpoint-max($hero-bg-image-bp) {
+  @include breakpoint-max($hero-bg-image-bp, true) {
     font-size: rem(gesso-font-size(2));
     margin-bottom: rem(gesso-spacing(3));
   }

--- a/source/_patterns/04-components/hero-bg-image/_hero-bg-image.scss
+++ b/source/_patterns/04-components/hero-bg-image/_hero-bg-image.scss
@@ -36,7 +36,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   color: gesso-color(text, on-dark);
   margin-bottom: rem(gesso-spacing(5));
 
-  @include breakpoint($hero-bg-image-bp, 'max') {
+  @include breakpoint-max($hero-bg-image-bp) {
     font-size: rem(gesso-font-size(7));
     margin-bottom: rem(gesso-spacing(3));
   }
@@ -47,7 +47,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   color: gesso-color(text, on-dark);
   margin-bottom: rem(gesso-spacing(5));
 
-  @include breakpoint($hero-bg-image-bp, 'max') {
+  @include breakpoint-max($hero-bg-image-bp) {
     font-size: rem(gesso-font-size(2));
     margin-bottom: rem(gesso-spacing(3));
   }

--- a/source/_patterns/04-components/hero-inline-image/_hero-inline-image.scss
+++ b/source/_patterns/04-components/hero-inline-image/_hero-inline-image.scss
@@ -65,7 +65,7 @@ $hero-inline-image-bp: gesso-breakpoint(desktop) !default;
     margin-bottom: rem(gesso-spacing(5));
   }
 
-  @include breakpoint($hero-inline-image-bp, 'max') {
+  @include breakpoint-max($hero-inline-image-bp) {
     font-size: rem(gesso-font-size(7));
   }
 }

--- a/source/_patterns/04-components/hero-inline-image/_hero-inline-image.scss
+++ b/source/_patterns/04-components/hero-inline-image/_hero-inline-image.scss
@@ -65,7 +65,7 @@ $hero-inline-image-bp: gesso-breakpoint(desktop) !default;
     margin-bottom: rem(gesso-spacing(5));
   }
 
-  @include breakpoint-max($hero-inline-image-bp) {
+  @include breakpoint-max($hero-inline-image-bp, true) {
     font-size: rem(gesso-font-size(7));
   }
 }

--- a/source/_patterns/04-components/view/_view.scss
+++ b/source/_patterns/04-components/view/_view.scss
@@ -5,7 +5,7 @@
   // hides certain table cells on small screens if enabled within the
   // settings of a view using the table format
   table.responsive-enabled {
-    @include breakpoint(gesso-breakpoint(tablet), 'max') {
+    @include breakpoint-max(gesso-breakpoint(tablet)) {
       th.priority-low,
       td.priority-low,
       th.priority-medium,
@@ -13,7 +13,7 @@
         display: none;
       }
     }
-    @include breakpoint(gesso-breakpoint(tablet-lg), 'max') {
+    @include breakpoint-max(gesso-breakpoint(tablet-lg)) {
       th.priority-low,
       td.priority-low {
         display: none;

--- a/source/_patterns/04-components/view/_view.scss
+++ b/source/_patterns/04-components/view/_view.scss
@@ -5,7 +5,7 @@
   // hides certain table cells on small screens if enabled within the
   // settings of a view using the table format
   table.responsive-enabled {
-    @include breakpoint-max(gesso-breakpoint(tablet)) {
+    @include breakpoint-max(gesso-breakpoint(tablet), true) {
       th.priority-low,
       td.priority-low,
       th.priority-medium,
@@ -13,7 +13,7 @@
         display: none;
       }
     }
-    @include breakpoint-max(gesso-breakpoint(tablet-lg)) {
+    @include breakpoint-max(gesso-breakpoint(tablet-lg), true) {
       th.priority-low,
       td.priority-low {
         display: none;


### PR DESCRIPTION
@dcmouyard @kmonahan Here's my pass at adjusting the breakpoint mixins to handle multiple values and refactored how it handles max-width.  

I'm leaning towards NOT having it automagically subtract 1px when using max-width, partly b/c I couldn't figure out how to only apply it when using `gesso-breakpoint` values, but also because I'm not sure we want that to be the default behavior.  I'm still thinking that through, but if we do want it to be the default behavior, maybe we add a flag to disable/enable it?    

I didn't want that to hold up getting the basics of this in place, so let me know what you think of these changes and if you think we should continue down that path of the 1px subtraction, how you think that should best be implemented.  