### PR TITLE
adds responsive layout table

### DIFF
--- a/source/_patterns/03-layouts/responsive-table/_responsive-table.scss
+++ b/source/_patterns/03-layouts/responsive-table/_responsive-table.scss
@@ -1,0 +1,3 @@
+.l-responsive-table {
+  overflow-x: auto;
+}

--- a/source/_patterns/03-layouts/responsive-table/_responsive-table.scss
+++ b/source/_patterns/03-layouts/responsive-table/_responsive-table.scss
@@ -1,3 +1,4 @@
 .l-responsive-table {
+  @include focus();
   overflow-x: auto;
 }

--- a/source/_patterns/03-layouts/responsive-table/responsive-table.md
+++ b/source/_patterns/03-layouts/responsive-table/responsive-table.md
@@ -1,0 +1,8 @@
+---
+el: .l-responsive-table
+title: Responsive Table
+---
+
+__Variables:__
+* labeled_by: [string] ID of table caption.
+* table: [object] Table element content.

--- a/source/_patterns/03-layouts/responsive-table/responsive-table.twig
+++ b/source/_patterns/03-layouts/responsive-table/responsive-table.twig
@@ -1,0 +1,3 @@
+<div class="l-responsive-table" role="region" tabindex="0"{% if labeled_by %} aria-labelledby="{{ labeled_by }}"{% endif %}>
+  {{ table }}
+</div>

--- a/source/_patterns/03-layouts/responsive-table/responsive-table.yml
+++ b/source/_patterns/03-layouts/responsive-table/responsive-table.yml
@@ -1,0 +1,72 @@
+---
+labeld_by: 'tablecaption01'
+table: |-
+  <table>
+    <caption id="tablecaption01">Table caption</caption>
+    <thead>
+      <tr>
+        <th>Table Heading A</th>
+        <th>Table Heading B</th>
+        <th>Table Heading C</th>
+        <th>Table Heading D</th>
+        <th>Table Heading E</th>
+        <th>Table Heading F</th>
+        <th>Table Heading G</th>
+        <th>Table Heading H</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr>
+        <th>Table Footer A</th>
+        <th>Table Footer B</th>
+        <th>Table Footer C</th>
+        <th>Table Footer D</th>
+        <th>Table Footer E</th>
+        <th>Table Footer F</th>
+        <th>Table Footer G</th>
+        <th>Table Footer H</th>
+      </tr>
+    </tfoot>
+    <tbody>
+      <tr>
+        <td>Table Cell A1</td>
+        <td>Table Cell B1</td>
+        <td>Table Cell C1</td>
+        <td>Table Cell D1</td>
+        <td>Table Cell E1</td>
+        <td>Table Cell F1</td>
+        <td>Table Cell G1</td>
+        <td>Table Cell H1</td>
+      </tr>
+      <tr>
+        <td>Table Cell A2</td>
+        <td>Table Cell B2</td>
+        <td>Table Cell C2</td>
+        <td>Table Cell D2</td>
+        <td>Table Cell E2</td>
+        <td>Table Cell F2</td>
+        <td>Table Cell G2</td>
+        <td>Table Cell H2</td>
+      </tr>
+      <tr>
+        <td>Table Cell A3</td>
+        <td>Table Cell B3</td>
+        <td>Table Cell C3</td>
+        <td>Table Cell D3</td>
+        <td>Table Cell E3</td>
+        <td>Table Cell F3</td>
+        <td>Table Cell G3</td>
+        <td>Table Cell H3</td>
+      </tr>
+      <tr>
+        <td>Table Cell A4</td>
+        <td>Table Cell B4</td>
+        <td>Table Cell C4</td>
+        <td>Table Cell D4</td>
+        <td>Table Cell E4</td>
+        <td>Table Cell F4</td>
+        <td>Table Cell G4</td>
+        <td>Table Cell H4</td>
+      </tr>
+    </tbody>
+  </table>

--- a/source/_patterns/03-layouts/responsive-table/responsive-table.yml
+++ b/source/_patterns/03-layouts/responsive-table/responsive-table.yml
@@ -1,5 +1,5 @@
 ---
-labeld_by: 'tablecaption01'
+labeled_by: 'tablecaption01'
 table: |-
   <table>
     <caption id="tablecaption01">Table caption</caption>


### PR DESCRIPTION
This code is based off of: https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html

I initially tried adding `display: block` and `overflow-x: auto` to all table elements, which is simpler and works in many cases.  However, by changing the display property of the table element, tables (or more accurately, their child elements) cease to go full width even with `min-width: 100%` on the table element, so I don't think that approach can be applied across the board for all tables.  

After doing some research, it seems a wrapper element around the table is the preferred method for making large tables scrollable at mobile size, so I've added this layout for that purpose.  