### PR TITLE
Fix accessibility of back to top component

### DIFF
--- a/js/src/modules/_back-to-top.es6.js
+++ b/js/src/modules/_back-to-top.es6.js
@@ -10,17 +10,20 @@ export default function (threshold = 200, smoothScroll = true) {
   if (backToTop) {
     if (!isNaN(threshold)) {
       backToTop.setAttribute('aria-hidden', 'true');
+      backToTop.setAttribute('tabIndex', '-1');
       const scrollHandler = () => {
         if (
           window.scrollY >= threshold &&
           backToTop.getAttribute('aria-hidden') === 'true'
         ) {
           backToTop.setAttribute('aria-hidden', 'false');
+          backToTop.removeAttribute('tabIndex');
         } else if (
           window.scrollY < threshold &&
           backToTop.getAttribute('aria-hidden', 'false')
         ) {
           backToTop.setAttribute('aria-hidden', 'true');
+          backToTop.setAttribute('tabIndex', '-1');
         }
       };
       let stillScrolling = false;


### PR DESCRIPTION
The current implementation allows the back to top link to be tabbed to via keyboard while it still has the aria-hidden attribute set to true, which is an accessibility issue. This PR fixes that.