### PR TITLE
fixes traversable error when webform uses fieldset template

### DIFF
--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -3,6 +3,8 @@
   required ? 'is-required',
 ] %}
 
+{% set removeClasses = [] %}
+
 {% if type == 'fieldset' %}
   {% set addClasses = addClasses|merge([
     'fieldset--default',


### PR DESCRIPTION
This sets removeClasses as an empty array to avoid the merge filter error reported in #477.

Closes #477.
 