### PR TITLE
ensures forms have unique ids

### DIFF
--- a/templates/form/form.html.twig
+++ b/templates/form/form.html.twig
@@ -10,6 +10,6 @@
  * @see template_preprocess_form()
  */
 #}
-<form{{ attributes }}>
+<form{{ attributes.setAttribute('id', attributes.id|unique_id) }}>
   {{ children }}
 </form>


### PR DESCRIPTION
This ensures forms have unique ids in the rare cases the same form might appear on a page twice.  