### PR TITLE
Allow Sass partials to include assets from core

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -94,7 +94,18 @@ module.exports = {
         exclude: /node_modules/,
         use: [
           MiniCssExtractPlugin.loader,
-          'css-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              url: (url) => {
+                // Ignore `/core/` urls.
+                if (url.includes('/core/')) {
+                  return false;
+                }
+                return true;
+              },
+            },
+          },
           {
             loader: 'sass-loader',
             options: {


### PR DESCRIPTION
While trying to fix the Quickedit issue, I noticed that we couldn’t use any core assets in our Sass partials. (e.g., `background-image: url(/core/modules/quickedit/images/icon-throbber.gif);`) This PR fixes that error by bypassing any urls with `/core/` in it.