### PR TITLE
Responsive typography

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -145,6 +145,10 @@ function getScalarVisitor(path) {
       return identityTransformer;
     }
 
+    if (prefix === 'responsive-font-size') {
+      return identityTransformer;
+    }
+
     if (prefix === 'color') {
       return colorTransformer;
     }

--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -246,47 +246,47 @@ gesso:
       display:
         color: text.primary
         font-family: primary.stack
-        font-size: 10
         font-weight: bold
         line-height: tight
+        responsive-font-size: 10
       h1:
         color: text.primary
         font-family: primary.stack
-        font-size: 8
         font-weight: bold
         line-height: tight
+        responsive-font-size: 8
       h2:
         color: text.primary
         font-family: primary.stack
-        font-size: 7
         font-weight: bold
         line-height: tight
+        responsive-font-size: 7
       h3:
         color: text.primary
         font-family: primary.stack
-        font-size: 6
         font-weight: bold
         line-height: tight
+        responsive-font-size: 6
       h4:
         color: text.primary
         font-family: primary.stack
-        font-size: 5
         font-weight: bold
         line-height: base
+        responsive-font-size: 5
       h5:
         color: text.primary
         font-family: primary.stack
-        font-size: 3
         font-weight: bold
         line-height: base
+        responsive-font-size: 3
       h6:
         color: text.primary
         font-family: primary.stack
-        font-size: 2
         font-weight: semibold
         letter-spacing: -0.04em
         line-height: loose
         text-transform: uppercase
+        responsive-font-size: 2
       blockquote:
         color: text.link
         font-family: primary.stack

--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -190,6 +190,49 @@ gesso:
       8: 56px
       9: 64px
       10: 80px
+    responsive-font-size-min-width: 360px
+    responsive-font-size-max-width: 1600px
+    responsive-font-size:
+      1:
+        min: 12px
+        val: auto
+        max: 12px
+      2:
+        min: 16px
+        val: auto
+        max: 16px
+      3:
+        min: 18px
+        val: auto
+        max: 20px
+      4:
+        min: 20px
+        val: auto
+        max: 24px
+      5:
+        min: 24px
+        val: auto
+        max: 32px
+      6:
+        min: 28px
+        val: auto
+        max: 40px
+      7:
+        min: 32px
+        val: auto
+        max: 48px
+      8:
+        min: 36px
+        val: auto
+        max: 56px
+      9:
+        min: 40px
+        val: auto
+        max: 64px
+      10:
+        min: 50px
+        val: auto
+        max: 80px
     font-weight:
       light: 300
       regular: 400

--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -181,15 +181,15 @@ gesso:
     base-font-size: 16px
     font-size:
       1: 12px
-      2: 16px
-      3: 20px
-      4: 24px
-      5: 32px
-      6: 40px
-      7: 48px
-      8: 56px
-      9: 64px
-      10: 80px
+      2: 14px
+      3: 16px
+      4: 20px
+      5: 25px
+      6: 31.25px
+      7: 39.06625px
+      8: 48.8281px
+      9: 61.0352px
+      10: 76.2939px
     responsive-font-size-min-width: 360px
     responsive-font-size-max-width: 1600px
     responsive-font-size:
@@ -198,41 +198,41 @@ gesso:
         val: auto
         max: 12px
       2:
+        min: 14px
+        val: auto
+        max: 14px
+      3:
         min: 16px
         val: auto
         max: 16px
-      3:
+      4:
         min: 18px
         val: auto
         max: 20px
-      4:
-        min: 20px
-        val: auto
-        max: 24px
       5:
-        min: 24px
+        min: 20.25px
         val: auto
-        max: 32px
+        max: 25px
       6:
-        min: 28px
+        min: 22.7813px
         val: auto
-        max: 40px
+        max: 31.25px
       7:
-        min: 32px
+        min: 25.6289px
         val: auto
-        max: 48px
+        max: 39.0625px
       8:
-        min: 36px
+        min: 28.8325px
         val: auto
-        max: 56px
+        max: 48.8281px
       9:
-        min: 40px
+        min: 32.4366px
         val: auto
-        max: 64px
+        max: 61.0352px
       10:
-        min: 50px
+        min: 36.4912px
         val: auto
-        max: 80px
+        max: 76.2939px
     font-weight:
       light: 300
       regular: 400
@@ -246,43 +246,43 @@ gesso:
       display:
         color: text.primary
         font-family: primary.stack
-        font-size: 9
+        font-size: 10
         font-weight: bold
         line-height: tight
       h1:
         color: text.primary
         font-family: primary.stack
-        font-size: 7
+        font-size: 8
         font-weight: bold
         line-height: tight
       h2:
         color: text.primary
         font-family: primary.stack
-        font-size: 6
+        font-size: 7
         font-weight: bold
         line-height: tight
       h3:
         color: text.primary
         font-family: primary.stack
-        font-size: 5
+        font-size: 6
         font-weight: bold
         line-height: tight
       h4:
         color: text.primary
         font-family: primary.stack
-        font-size: 4
+        font-size: 5
         font-weight: bold
         line-height: base
       h5:
         color: text.primary
         font-family: primary.stack
-        font-size: 2
+        font-size: 3
         font-weight: bold
         line-height: base
       h6:
         color: text.primary
         font-family: primary.stack
-        font-size: 1
+        font-size: 2
         font-weight: semibold
         letter-spacing: -0.04em
         line-height: loose
@@ -290,25 +290,25 @@ gesso:
       blockquote:
         color: text.link
         font-family: primary.stack
-        font-size: 4
+        font-size: 5
         font-weight: regular
         line-height: base
       body:
         color: text.primary
         font-family: primary.stack
-        font-size: 2
+        font-size: 3
         font-weight: regular
         line-height: base
       body-large:
         color: text.primary
         font-family: primary.stack
-        font-size: 3
+        font-size: 4
         font-weight: regular
         line-height: base
       cite:
         color: text.secondary
         font-family: primary.stack
-        font-size: 1
+        font-size: 2
         font-style: normal
         font-weight: semibold
         letter-spacing: .02em

--- a/source/00-config/mixins/_display-text-style.scss
+++ b/source/00-config/mixins/_display-text-style.scss
@@ -1,12 +1,15 @@
 // Mixins: Display Text Style
 
 @use '../functions' as *;
+@use './responsive-font-size' as *;
 
 @mixin display-text-style($keys...) {
   $display: gesso-get-map(typography, display, $keys...);
 
   @each $property, $value in $display {
-    @if ($property == 'font-size') {
+    @if ($property == 'responsive-font-size') {
+      @include responsive-font-size($value);
+    } @else if ($property == 'font-size') {
       // Check for px if not output value.
       #{$property}: #{rem(convert($value))};
     } @else {

--- a/source/00-config/mixins/_index.scss
+++ b/source/00-config/mixins/_index.scss
@@ -11,4 +11,5 @@
 @forward 'link';
 @forward 'list';
 @forward 'mod-selector';
+@forward 'responsive-font-size';
 @forward 'svg-background';

--- a/source/00-config/mixins/_responsive-font-size.scss
+++ b/source/00-config/mixins/_responsive-font-size.scss
@@ -1,0 +1,41 @@
+// Mixins: Responsive Font Size
+
+@use '../config.settings' as *;
+@use '../functions' as *;
+
+@mixin responsive-font-size($font-scale) {
+  $min-size: rem(
+    gesso-get-map(typography, responsive-font-size, $font-scale, min)
+  );
+  $max-size: rem(
+    gesso-get-map(typography, responsive-font-size, $font-scale, max)
+  );
+
+  @if $min-size == $max-size {
+    font-size: $min-size;
+  } @else {
+    $ideal-size: gesso-get-map(
+      typography,
+      responsive-font-size,
+      $font-scale,
+      val
+    );
+    @if $ideal-size == 'auto' {
+      // For more details on how we calculate the ideal size:
+      // https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+      $min-width: rem(
+        gesso-get-map(typography, responsive-font-size-min-width)
+      );
+      $max-width: rem(
+        gesso-get-map(typography, responsive-font-size-max-width)
+      );
+      $slope: ($max-size - $min-size) / ($max-width - $min-width);
+      $intersection: -1 * $min-width * $slope + $min-size;
+      $ideal-size: $intersection + ' + ' + $slope * 100vw;
+    }
+
+    font-size: clamp(#{$min-size}, #{$ideal-size}, #{$max-size});
+    // stylelint-disable-next-line
+    -webkit-marquee-increment: 0vw; // Needed to get clamp() to work in Safari.
+  }
+}

--- a/source/01-global/01-typography/fonts.stories.jsx
+++ b/source/01-global/01-typography/fonts.stories.jsx
@@ -5,7 +5,7 @@ import data from '../../00-config/config.design-tokens.yml';
 import './fonts.scss';
 
 const settings = {
-  title: 'Global/Fonts',
+  title: 'Global/Typography/Fonts',
   argTypes: {
     gesso: {
       table: {

--- a/source/01-global/01-typography/text-styles.scss
+++ b/source/01-global/01-typography/text-styles.scss
@@ -9,3 +9,9 @@
 .gesso-storybook-text-style__label {
   text-transform: uppercase;
 }
+
+@each $name, $style in gesso-get-map(typography, display) {
+  .gesso-storybook-text-style__preview--#{$name} {
+    @include display-text-style($name);
+  }
+}

--- a/source/01-global/01-typography/text-styles.twig
+++ b/source/01-global/01-typography/text-styles.twig
@@ -1,13 +1,8 @@
 {% for name, style in gesso.typography.display %}
 
-  {% set rendered_style = '' %}
-  {% for prop, value in style %}
-    {% set rendered_style = prop ~ ': ' ~ value ~ '; ' ~ rendered_style %}
-  {% endfor %}
-
-  <div class="gesso-storybook-text-style">
+  <div class="gesso-storybook-text-style gesso-storybook-text-style--{{ name }}">
     <div class="gesso-storybook-text-style__label">{{name}}</div>
-    <div class="gesso-storybook-text-style__preview" style='{{rendered_style}}'>
+    <div class="gesso-storybook-text-style__preview gesso-storybook-text-style__preview--{{ name }}">
       Alice was beginning to get very tired of sitting by her sister on the bank, and of having nothing to do: once or twice she had peeped into the book her sister was reading, but it had no pictures or conversations in it, ‘and what is the use of a book,’ thought Alice ‘without pictures or conversations?’
     </div>
   </div>

--- a/source/01-global/01-typography/typographic-scale.scss
+++ b/source/01-global/01-typography/typographic-scale.scss
@@ -1,0 +1,20 @@
+// Storybook: Typographic Scale
+
+@use '00-config' as *;
+
+.gesso-storybook-typographic-scale {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  line-height: 1;
+  margin: 1rem;
+}
+
+.gesso-storybook-typographic-scale__label {
+  font-weight: bold;
+}
+
+.gesso-storybook-typographic-scale__preview {
+  // stylelint-disable-next-line
+  -webkit-marquee-increment: 0vw; // Needed to get clamp() to work in Safari.
+}

--- a/source/01-global/01-typography/typographic-scale.scss
+++ b/source/01-global/01-typography/typographic-scale.scss
@@ -3,14 +3,26 @@
 @use '00-config' as *;
 
 .gesso-storybook-typographic-scale {
+  margin: 1rem 1rem 3rem;
+}
+
+.gesso-storybook-typographic-scale__heading {
+  font-family: gesso-font-family(system);
+  font-size: 1.25rem;
+  line-height: 1.25;
+  margin-bottom: 1rem;
+}
+
+.gesso-storybook-typographic-scale__row {
   align-items: center;
   display: flex;
   gap: 1rem;
-  line-height: 1;
-  margin: 1rem;
+  line-height: gesso-line-height(tight);
+  margin: 1rem 0;
 }
 
 .gesso-storybook-typographic-scale__label {
+  font-family: gesso-font-family(system);
   font-weight: bold;
 }
 

--- a/source/01-global/01-typography/typographic-scale.stories.jsx
+++ b/source/01-global/01-typography/typographic-scale.stories.jsx
@@ -1,11 +1,11 @@
 import parse from 'html-react-parser';
 
-import twigTemplate from './text-styles.twig';
+import twigTemplate from './typographic-scale.twig';
 import data from '../../00-config/config.design-tokens.yml';
-import './text-styles.scss';
+import './typographic-scale.scss';
 
 const settings = {
-  title: 'Global/Typography/Text Styles',
+  title: 'Global/Typography/Typographic Scale',
   argTypes: {
     gesso: {
       table: {
@@ -15,12 +15,12 @@ const settings = {
   }
 };
 
-const TextStyles = args => (
+const TypographicScale = args => (
   parse(twigTemplate({
     ...args,
   }))
 );
-TextStyles.args = { ...data };
+TypographicScale.args = { ...data };
 
 export default settings;
-export { TextStyles };
+export { TypographicScale };

--- a/source/01-global/01-typography/typographic-scale.twig
+++ b/source/01-global/01-typography/typographic-scale.twig
@@ -1,35 +1,46 @@
-{% for number, font_size in gesso.typography['responsive-font-size'] %}
-  {% set rendered_style = '' %}
+{% set demo_content %}
+  {% for number, font_size in gesso.typography['responsive-font-size'] %}
+    {% set rendered_style = '' %}
 
-  {% if font_size.min == font_size.max %}
-    {% set rendered_style = (font_size.min / gesso.typography['base-font-size']) ~ 'rem' %}
-  {% elseif font_size.val == 'auto' %}
-    {#
-      For more details on how we calculate the default value:
-      https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
-    #}
-    {% set min_width = (gesso.typography['responsive-font-size-min-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
-    {% set max_width = (gesso.typography['responsive-font-size-max-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
-    {% set slope = (((font_size.max / gesso.typography['base-font-size']) - (font_size.min / gesso.typography['base-font-size'])) / (max_width - min_width))|round(9, 'common') %}
-    {% set intersection = (-1 * min_width * slope + (font_size.min / gesso.typography['base-font-size']))|round(9, 'common') %}
-    {% set default_val = intersection ~ 'rem + ' ~ (100 * slope)|round(9, 'common') ~ 'vw' %}
-    {% set rendered_style = 'clamp(' ~
-      (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
-      default_val ~ ', ' ~
-      (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
-    %}
-  {% else %}
-    {% set rendered_style = 'clamp(' ~
-      (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
-      font_size.val ~ ', ' ~
-      (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
-    %}
-  {% endif %}
+    {% if font_size.min == font_size.max %}
+      {% set rendered_style = (font_size.min / gesso.typography['base-font-size']) ~ 'rem' %}
+    {% elseif font_size.val == 'auto' %}
+      {#
+        For more details on how we calculate the default value:
+        https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+      #}
+      {% set min_width = (gesso.typography['responsive-font-size-min-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
+      {% set max_width = (gesso.typography['responsive-font-size-max-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
+      {% set slope = (((font_size.max / gesso.typography['base-font-size']) - (font_size.min / gesso.typography['base-font-size'])) / (max_width - min_width))|round(9, 'common') %}
+      {% set intersection = (-1 * min_width * slope + (font_size.min / gesso.typography['base-font-size']))|round(9, 'common') %}
+      {% set default_val = intersection ~ 'rem + ' ~ (100 * slope)|round(9, 'common') ~ 'vw' %}
+      {% set rendered_style = 'clamp(' ~
+        (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
+        default_val ~ ', ' ~
+        (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
+      %}
+    {% else %}
+      {% set rendered_style = 'clamp(' ~
+        (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
+        font_size.val ~ ', ' ~
+        (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
+      %}
+    {% endif %}
 
+    <div class="gesso-storybook-typographic-scale__row">
+      <div class="gesso-storybook-typographic-scale__label">{{ number }}</div>
+      <div class="gesso-storybook-typographic-scale__preview" style="font-size: {{ rendered_style }}">
+        This text goes from {{ font_size.min }} to {{ font_size.max }}.
+      </div>
+    </div>
+  {% endfor %}
+{% endset %}
+
+{% for name, item in gesso.typography['font-family'] %}
   <div class="gesso-storybook-typographic-scale">
-    <div class="gesso-storybook-typographic-scale__label">{{ number }}</div>
-    <div class="gesso-storybook-typographic-scale__preview" style="font-size: {{ rendered_style }}">
-      This text goes from {{ font_size.min }} to {{ font_size.max }}.
+    <h2 class="gesso-storybook-typographic-scale__heading">{{ item.name }}</h2>
+    <div style='font-family: {{ item.stack }}'>
+      {{ demo_content }}
     </div>
   </div>
 {% endfor %}

--- a/source/01-global/01-typography/typographic-scale.twig
+++ b/source/01-global/01-typography/typographic-scale.twig
@@ -1,0 +1,35 @@
+{% for number, font_size in gesso.typography['responsive-font-size'] %}
+  {% set rendered_style = '' %}
+
+  {% if font_size.min == font_size.max %}
+    {% set rendered_style = (font_size.min / gesso.typography['base-font-size']) ~ 'rem' %}
+  {% elseif font_size.val == 'auto' %}
+    {#
+      For more details on how we calculate the default value:
+      https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+    #}
+    {% set min_width = (gesso.typography['responsive-font-size-min-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
+    {% set max_width = (gesso.typography['responsive-font-size-max-width'] / gesso.typography['base-font-size']) ~ 'rem' %}
+    {% set slope = (((font_size.max / gesso.typography['base-font-size']) - (font_size.min / gesso.typography['base-font-size'])) / (max_width - min_width))|round(9, 'common') %}
+    {% set intersection = (-1 * min_width * slope + (font_size.min / gesso.typography['base-font-size']))|round(9, 'common') %}
+    {% set default_val = intersection ~ 'rem + ' ~ (100 * slope)|round(9, 'common') ~ 'vw' %}
+    {% set rendered_style = 'clamp(' ~
+      (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
+      default_val ~ ', ' ~
+      (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
+    %}
+  {% else %}
+    {% set rendered_style = 'clamp(' ~
+      (font_size.min / gesso.typography['base-font-size']) ~ 'rem, ' ~
+      font_size.val ~ ', ' ~
+      (font_size.max / gesso.typography['base-font-size']) ~ 'rem)'
+    %}
+  {% endif %}
+
+  <div class="gesso-storybook-typographic-scale">
+    <div class="gesso-storybook-typographic-scale__label">{{ number }}</div>
+    <div class="gesso-storybook-typographic-scale__preview" style="font-size: {{ rendered_style }}">
+      This text goes from {{ font_size.min }} to {{ font_size.max }}.
+    </div>
+  </div>
+{% endfor %}

--- a/source/01-global/html-elements/13-headings/_headings.scss
+++ b/source/01-global/html-elements/13-headings/_headings.scss
@@ -30,42 +30,36 @@ h1,
 %h1 {
   @extend %hN;
   @include display-text-style(h1);
-  @include responsive-font-size(8);
 }
 
 h2,
 %h2 {
   @extend %hN;
   @include display-text-style(h2);
-  @include responsive-font-size(7);
 }
 
 h3,
 %h3 {
   @extend %hN;
   @include display-text-style(h3);
-  @include responsive-font-size(6);
 }
 
 h4,
 %h4 {
   @extend %hN;
   @include display-text-style(h4);
-  @include responsive-font-size(5);
 }
 
 h5,
 %h5 {
   @extend %hN;
   @include display-text-style(h5);
-  @include responsive-font-size(3);
 }
 
 h6,
 %h6 {
   @extend %hN;
   @include display-text-style(h6);
-  @include responsive-font-size(2);
 }
 
 h1,

--- a/source/01-global/html-elements/13-headings/_headings.scss
+++ b/source/01-global/html-elements/13-headings/_headings.scss
@@ -30,52 +30,42 @@ h1,
 %h1 {
   @extend %hN;
   @include display-text-style(h1);
-
-  @include breakpoint-max(gesso-breakpoint(tablet), true) {
-    font-size: rem(gesso-font-size(5));
-  }
+  @include responsive-font-size(7);
 }
 
 h2,
 %h2 {
   @extend %hN;
   @include display-text-style(h2);
-
-  @include breakpoint-max(gesso-breakpoint(tablet), true) {
-    font-size: rem(gesso-font-size(4));
-  }
+  @include responsive-font-size(6);
 }
 
 h3,
 %h3 {
   @extend %hN;
   @include display-text-style(h3);
-
-  @include breakpoint-max(gesso-breakpoint(tablet), true) {
-    font-size: rem(gesso-font-size(3));
-  }
+  @include responsive-font-size(5);
 }
 
 h4,
 %h4 {
   @extend %hN;
   @include display-text-style(h4);
-
-  @include breakpoint-max(gesso-breakpoint(tablet), true) {
-    font-size: rem(gesso-font-size(2));
-  }
+  @include responsive-font-size(4);
 }
 
 h5,
 %h5 {
   @extend %hN;
   @include display-text-style(h5);
+  @include responsive-font-size(2);
 }
 
 h6,
 %h6 {
   @extend %hN;
   @include display-text-style(h6);
+  @include responsive-font-size(1);
 }
 
 h1,

--- a/source/01-global/html-elements/13-headings/_headings.scss
+++ b/source/01-global/html-elements/13-headings/_headings.scss
@@ -30,42 +30,42 @@ h1,
 %h1 {
   @extend %hN;
   @include display-text-style(h1);
-  @include responsive-font-size(7);
+  @include responsive-font-size(8);
 }
 
 h2,
 %h2 {
   @extend %hN;
   @include display-text-style(h2);
-  @include responsive-font-size(6);
+  @include responsive-font-size(7);
 }
 
 h3,
 %h3 {
   @extend %hN;
   @include display-text-style(h3);
-  @include responsive-font-size(5);
+  @include responsive-font-size(6);
 }
 
 h4,
 %h4 {
   @extend %hN;
   @include display-text-style(h4);
-  @include responsive-font-size(4);
+  @include responsive-font-size(5);
 }
 
 h5,
 %h5 {
   @extend %hN;
   @include display-text-style(h5);
-  @include responsive-font-size(2);
+  @include responsive-font-size(3);
 }
 
 h6,
 %h6 {
   @extend %hN;
   @include display-text-style(h6);
-  @include responsive-font-size(1);
+  @include responsive-font-size(2);
 }
 
 h1,

--- a/source/03-components/breadcrumb/_breadcrumb.scss
+++ b/source/03-components/breadcrumb/_breadcrumb.scss
@@ -11,7 +11,7 @@ $breadcrumb-text-color: gesso-color(text, on-dark) !default;
   @include clearfix();
   background-color: $breadcrumb-background-color;
   color: $breadcrumb-text-color;
-  font-size: rem(gesso-font-size(1));
+  font-size: rem(gesso-font-size(2));
   margin: gesso-spacing(4) 0;
   min-height: rem(40px);
   padding-bottom: gesso-spacing(2);

--- a/source/03-components/button/_button.scss
+++ b/source/03-components/button/_button.scss
@@ -75,7 +75,7 @@
 
 // This custom button class, included as an example, is not output by Drupal by default.
 .c-button--large {
-  font-size: rem(gesso-font-size(3));
+  font-size: rem(gesso-font-size(4));
   padding: rem(gesso-spacing(2)) rem(gesso-spacing(5));
 }
 

--- a/source/03-components/card/_card.scss
+++ b/source/03-components/card/_card.scss
@@ -22,7 +22,7 @@ $card-padding: rem(gesso-spacing(3)) !default;
 }
 
 .c-card__title {
-  font-size: rem(gesso-font-size(4));
+  font-size: rem(gesso-font-size(5));
   margin: 0;
 
   a {
@@ -43,7 +43,7 @@ $card-padding: rem(gesso-spacing(3)) !default;
 
 .c-card__date {
   color: $card-meta-color;
-  font-size: rem(gesso-font-size(1));
+  font-size: rem(gesso-font-size(2));
   margin-bottom: rem(gesso-spacing(2));
 }
 
@@ -86,7 +86,7 @@ $card-padding: rem(gesso-spacing(3)) !default;
     flex-direction: row;
 
     .c-card__title {
-      font-size: rem(gesso-font-size(5));
+      font-size: rem(gesso-font-size(6));
     }
 
     .c-card__body {

--- a/source/03-components/date/_date.scss
+++ b/source/03-components/date/_date.scss
@@ -4,5 +4,5 @@
 
 .c-date {
   color: gesso-color(text, secondary);
-  font-size: rem(gesso-font-size(2));
+  font-size: rem(gesso-font-size(3));
 }

--- a/source/03-components/details/_details.scss
+++ b/source/03-components/details/_details.scss
@@ -11,7 +11,7 @@ $details-text-color: gesso-color(text, on-light) !default;
 // 'details' can appear as a modernizr class on the html tag, so this
 // class is limited to only the details element
 .c-details {
-  margin: 0 0 rem(gesso-spacing(3));
+  margin: 0 0 rem(gesso-spacing(4));
 }
 
 .c-details__summary {

--- a/source/03-components/hamburger-button/hamburger-button.scss
+++ b/source/03-components/hamburger-button/hamburger-button.scss
@@ -12,7 +12,7 @@
   cursor: pointer;
   display: inline-block;
   font-family: gesso-font-family(system);
-  font-size: rem(gesso-font-size(2));
+  font-size: rem(gesso-font-size(3));
   font-weight: gesso-font-weight(bold);
   height: 55px;
   line-height: 55px;

--- a/source/03-components/hero-bg-image/hero-bg-image.scss
+++ b/source/03-components/hero-bg-image/hero-bg-image.scss
@@ -45,7 +45,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   margin-bottom: rem(gesso-spacing(5));
 
   @include breakpoint-max($hero-bg-image-bp, true) {
-    font-size: rem(gesso-font-size(7));
+    font-size: rem(gesso-font-size(8));
     margin-bottom: rem(gesso-spacing(3));
   }
 }
@@ -56,7 +56,7 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   margin-bottom: rem(gesso-spacing(5));
 
   @include breakpoint-max($hero-bg-image-bp, true) {
-    font-size: rem(gesso-font-size(2));
+    font-size: rem(gesso-font-size(3));
     margin-bottom: rem(gesso-spacing(3));
   }
 }

--- a/source/03-components/hero-inline-image/hero-inline-image.scss
+++ b/source/03-components/hero-inline-image/hero-inline-image.scss
@@ -67,7 +67,7 @@ $hero-inline-image-bp: gesso-breakpoint(desktop) !default;
   }
 
   @include breakpoint-max($hero-inline-image-bp, true) {
-    font-size: rem(gesso-font-size(7));
+    font-size: rem(gesso-font-size(8));
   }
 }
 

--- a/source/03-components/mega-menu/mega-menu.scss
+++ b/source/03-components/mega-menu/mega-menu.scss
@@ -43,7 +43,7 @@
       border-bottom: rem(2px) solid transparent;
       border-radius: rem(1px);
       display: block;
-      font-size: rem(gesso-font-size(3));
+      font-size: rem(gesso-font-size(4));
       font-weight: gesso-font-weight(regular);
       padding: rem(4.8px) 0;
       position: relative;
@@ -55,7 +55,7 @@
 
     button.c-mega-menu__link {
       @include text-button;
-      font-size: rem(gesso-font-size(3));
+      font-size: rem(gesso-font-size(4));
     }
   }
 
@@ -136,8 +136,7 @@
 .c-mega-menu__section-title {
   color: gesso-color(text, on-dark);
   display: block;
-  font-size: rem(gesso-font-size(8));
-}
+  font-size: rem(gesso-font-size(9));
 
 .c-mega-menu__icon {
   transition: margin 0.2s;
@@ -167,7 +166,7 @@
 .c-mega-menu__subnav .c-mega-menu__link {
   border-bottom: 0;
   color: inherit;
-  font-size: rem(gesso-font-size(3));
+  font-size: rem(gesso-font-size(4));
   font-weight: gesso-font-weight(bold);
   position: static;
   text-decoration: none;

--- a/source/03-components/mega-menu/mega-menu.scss
+++ b/source/03-components/mega-menu/mega-menu.scss
@@ -137,6 +137,7 @@
   color: gesso-color(text, on-dark);
   display: block;
   font-size: rem(gesso-font-size(9));
+}
 
 .c-mega-menu__icon {
   transition: margin 0.2s;

--- a/source/03-components/menu/menu--account/_menu--account.scss
+++ b/source/03-components/menu/menu--account/_menu--account.scss
@@ -6,6 +6,6 @@
   @include list-pipeline();
 
   .c-menu__link {
-    font-size: rem(gesso-font-size(1));
+    font-size: rem(gesso-font-size(2));
   }
 }

--- a/source/03-components/mobile-menu/mobile-menu.scss
+++ b/source/03-components/mobile-menu/mobile-menu.scss
@@ -27,7 +27,7 @@ $mobile-menu-submenu-link-hover-color: gesso-color(
 ) !default;
 $mobile-menu-button-height: 54px;
 $mobile-menu-button-width: 44px;
-$mobile-menu-font-size: gesso-font-size(3);
+$mobile-menu-font-size: gesso-font-size(4);
 $mobile-menu-line-height: gesso-line-height(base);
 
 .c-mobile-menu {

--- a/source/03-components/overlay-menu/overlay-menu.scss
+++ b/source/03-components/overlay-menu/overlay-menu.scss
@@ -33,7 +33,7 @@ $overlay-menu-bg-color: rgba(
   align-items: center;
   display: flex;
   flex-flow: column nowrap;
-  font-size: rem(gesso-font-size(5));
+  font-size: rem(gesso-font-size(6));
   height: calc(100% - 55px);
   justify-content: center;
   width: 100%;

--- a/source/03-components/progress/_progress.scss
+++ b/source/03-components/progress/_progress.scss
@@ -38,7 +38,7 @@ $progress-text-color: gesso-color(text, on-light) !default;
 .c-progress__description,
 .c-progress__percentage {
   color: $progress-text-color;
-  font-size: rem(gesso-font-size(1));
+  font-size: rem(gesso-font-size(2));
   overflow: hidden;
 }
 

--- a/source/03-components/side-menu/side-menu.scss
+++ b/source/03-components/side-menu/side-menu.scss
@@ -7,7 +7,11 @@ $side-menu-bg-color: gesso-color(ui, generic, background-light);
 
 .c-side-menu {
   background: $side-menu-bg-color;
+<<<<<<< HEAD
   font-size: rem(gesso-font-size(3));
+=======
+  font-size: gesso-font-size(4);
+>>>>>>> Update default typographic scale
   height: 100vh;
   left: 0;
   overflow: hidden;
@@ -105,7 +109,7 @@ $side-menu-bg-color: gesso-color(ui, generic, background-light);
 }
 
 .c-side-menu__section-title {
-  font-size: rem(gesso-font-size(4));
+  font-size: rem(gesso-font-size(5));
   font-weight: gesso-font-weight(semibold);
   padding: gesso-spacing(1) gesso-spacing(2);
 }

--- a/source/03-components/side-menu/side-menu.scss
+++ b/source/03-components/side-menu/side-menu.scss
@@ -7,11 +7,7 @@ $side-menu-bg-color: gesso-color(ui, generic, background-light);
 
 .c-side-menu {
   background: $side-menu-bg-color;
-<<<<<<< HEAD
-  font-size: rem(gesso-font-size(3));
-=======
-  font-size: gesso-font-size(4);
->>>>>>> Update default typographic scale
+  font-size: rem(gesso-font-size(4));
   height: 100vh;
   left: 0;
   overflow: hidden;

--- a/source/03-components/tag/_tag.scss
+++ b/source/03-components/tag/_tag.scss
@@ -7,7 +7,7 @@
   border: 2px solid gesso-color(ui, generic, accent-light);
   border-radius: 70px;
   display: inline-block;
-  font-size: rem(gesso-font-size(1));
+  font-size: rem(gesso-font-size(2));
   margin: 0 0 rem(gesso-spacing(1));
   padding: 0.25em 1.65em;
   text-align: center;


### PR DESCRIPTION
This PR fixes #288 and does the following:

- Add responsive font size tokens that can be used in `clamp()`
- Move Fonts and Text Styles to a new Typography folder in Storybook
- Add new Typographic Scale demo in Storybook which uses the responsive font size tokens
- Add new `responsive-font-size()` mixin which is used for headings
- Responsive technique details: https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/

I think this PR needs a full review with the FED team before it gets merged in since it’s pretty opinionated regarding the responsive typography technique.