### PR TITLE
Update site-name markup

### DIFF
--- a/source/03-components/site-name/site-name.twig
+++ b/source/03-components/site-name/site-name.twig
@@ -9,5 +9,5 @@
   'title': 'Home'|t,
   'rel': 'home'
 }) }}>
-  <h1 class="c-site-name__text">{{ site_name }}</h1>
+  <span class="c-site-name__text">{{ site_name }}</span>
 </a>


### PR DESCRIPTION
Fixes #574. This PR switches the markup from using `h1` to a `span`. 