### PR TITLE
Update use of striptags filter

### DIFF
--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -80,7 +80,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/templates/content/taxonomy-term--full.html.twig
+++ b/templates/content/taxonomy-term--full.html.twig
@@ -29,7 +29,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 

--- a/templates/user/user--full.html.twig
+++ b/templates/user/user--full.html.twig
@@ -23,7 +23,7 @@
 
 {% set show_admin_info = false %}
 
-{% if admin_info|striptags|trim %}
+{% if admin_info|striptags('<drupal-render-placeholder>')|trim %}
   {% set show_admin_info = true %}
 {% endif %}
 


### PR DESCRIPTION
Fixes #582. This PR prevents us from stripping out essential Drupal functionality (such as hidden Drupal status messages) when checking if Twig variables are empty.