### PR TITLE
Append Sass file to index file when component created

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -254,14 +254,27 @@ async function createComponent(
         library
       )
     );
-    if (
-      !library &&
-      fs.existsSync(path.join(path.dirname(location), '_index.scss'))
-    ) {
+    const directories = location.split(path.sep);
+    const sassPath = [];
+    while (directories.length > 0) {
+      const dirname = directories.pop();
+      if (dirname === directory) {
+        break;
+      }
+      sassPath.unshift(dirname);
+    }
+    const sassIndex = path.join(
+      path.parse(location).root,
+      ...directories,
+      directory,
+      '_index.scss'
+    );
+    console.log(sassIndex);
+    if (fs.existsSync(sassIndex)) {
       filesArray.push(
         fsPromises.appendFile(
-          path.join(path.dirname(location), '_index.scss'),
-          `@use '${componentName}/${componentName}';${EOL}`
+          sassIndex,
+          `@use '${sassPath.join('/')}/${componentName}';${EOL}`
         )
       );
     }

--- a/lib/component.js
+++ b/lib/component.js
@@ -269,7 +269,6 @@ async function createComponent(
       directory,
       '_index.scss'
     );
-    console.log(sassIndex);
     if (fs.existsSync(sassIndex)) {
       filesArray.push(
         fsPromises.appendFile(

--- a/lib/component.js
+++ b/lib/component.js
@@ -2,9 +2,11 @@
 /* eslint-disable no-console */
 
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const inquirer = require('inquirer');
 const path = require('path');
 const mkdirp = require('mkdirp');
+const { EOL } = require('os');
 
 /**
  * Creates the machine name from a human-readable name.
@@ -243,8 +245,26 @@ async function createComponent(
     }
 
     const filesArray = ['scss', 'twig', 'yml', 'jsx'].map(ext =>
-      makeComponentFile(componentName, componentTitle, location, directory, ext, library)
+      makeComponentFile(
+        componentName,
+        componentTitle,
+        location,
+        directory,
+        ext,
+        library
+      )
     );
+    if (
+      !library &&
+      fs.existsSync(path.join(path.dirname(location), '_index.scss'))
+    ) {
+      filesArray.push(
+        fsPromises.appendFile(
+          path.join(path.dirname(location), '_index.scss'),
+          `@use '${componentName}/${componentName}';${EOL}`
+        )
+      );
+    }
     const success = await Promise.all(filesArray);
     if (success) {
       console.log(`${componentTitle} created`);


### PR DESCRIPTION
Adds a `@use` statement to the `_index.scss` file as part of `npm run component` for components that use a sass partial.