### PR TITLE
Make responsive-font-size mixin more modular so it can also be used for specific font sizes

### DIFF
--- a/source/00-config/functions/_font-size.scss
+++ b/source/00-config/functions/_font-size.scss
@@ -1,0 +1,12 @@
+@use 'gesso' as *;
+@use 'sass:math';
+@use 'unit-convert' as *;
+
+@function ideal-font-size($min-size, $max-size) {
+  $min-width: rem(gesso-get-map(typography, responsive-font-size-min-width));
+  $max-width: rem(gesso-get-map(typography, responsive-font-size-max-width));
+  $slope: math.div($max-size - $min-size, $max-width - $min-width);
+  $intersection: -1 * $min-width * $slope + $min-size;
+  $ideal-size: $intersection + ' + ' + $slope * 100vw;
+  @return $ideal-size;
+}

--- a/source/00-config/mixins/_responsive-font-size.scss
+++ b/source/00-config/mixins/_responsive-font-size.scss
@@ -1,42 +1,37 @@
 // Mixins: Responsive Font Size
 
-@use 'sass:math';
 @use '../config.settings' as *;
 @use '../functions' as *;
 
-@mixin responsive-font-size($font-scale) {
-  $min-size: rem(
-    gesso-get-map(typography, responsive-font-size, $font-scale, min)
-  );
-  $max-size: rem(
-    gesso-get-map(typography, responsive-font-size, $font-scale, max)
-  );
-
+@mixin custom-responsive-font-size($min-size, $max-size, $ideal-size: 'auto') {
+  $min-size: rem($max-size);
+  $max-size: rem($max-size);
   @if $min-size == $max-size {
     font-size: $min-size;
   } @else {
-    $ideal-size: gesso-get-map(
-      typography,
-      responsive-font-size,
-      $font-scale,
-      val
-    );
     @if $ideal-size == 'auto' {
       // For more details on how we calculate the ideal size:
       // https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
-      $min-width: rem(
-        gesso-get-map(typography, responsive-font-size-min-width)
-      );
-      $max-width: rem(
-        gesso-get-map(typography, responsive-font-size-max-width)
-      );
-      $slope: math.div($max-size - $min-size, $max-width - $min-width);
-      $intersection: -1 * $min-width * $slope + $min-size;
-      $ideal-size: $intersection + ' + ' + $slope * 100vw;
+      $ideal-size: ideal-font-size($min-size, $max-size);
+    } @else {
+      $ideal-size: rem($ideal-size);
     }
 
     font-size: clamp(#{$min-size}, #{$ideal-size}, #{$max-size});
     // stylelint-disable-next-line
     -webkit-marquee-increment: 0vw; // Needed to get clamp() to work in Safari.
   }
+}
+
+@mixin responsive-font-size($font-scale) {
+  $min-size: gesso-get-map(typography, responsive-font-size, $font-scale, min);
+  $max-size: gesso-get-map(typography, responsive-font-size, $font-scale, max);
+  $ideal-size: gesso-get-map(
+    typography,
+    responsive-font-size,
+    $font-scale,
+    val
+  );
+
+  @include custom-responsive-font-size($min-size, $max-size, $ideal-size);
 }


### PR DESCRIPTION
Splits the existing `responsive-font-size` mixin into a Sass function to calculate the ideal font size and a `custom-responsive-font-size` mixin that takes any minimum, maximum, and ideal font size. The purpose behind this is to allow for the same responsive font size approach to be used outside of the design tokens if and when one-off exceptions to the defined font scale come up (as they did for me last week).

So either will work:
`@include responsive-font-size(4)`
or
`@include custom-responsive-font-size(gesso-font-size(1), gesso-font-size(10), 'auto')`