### PR TITLE
Fix including common.js JS chunk as Gesso dependency

### DIFF
--- a/includes/libraries.inc
+++ b/includes/libraries.inc
@@ -6,17 +6,20 @@
  */
 
 /**
- * Implements hook_library_info_build().
+ * Implements hook_library_info_alter().
  */
-function gesso_library_info_build() {
-  $libraries = [];
-  $active_theme = \Drupal::theme()->getActiveTheme()->getPath();
-  if (file_exists($active_theme . '/dist/js/common.js')) {
+function gesso_library_info_alter(&$libraries, $extension) {
+  $activeTheme = \Drupal::theme()->getActiveTheme();
+  $activeThemePath = $activeTheme->getPath();
+
+  if ($extension === $activeTheme->getName()
+  && file_exists($activeThemePath . '/dist/js/common.js')) {
     $libraries['common'] = [
       'js' => [
         'dist/js/common.js' => [],
       ],
     ];
+
+    $libraries['global']['dependencies'][] = $extension . '/common';
   }
-  return $libraries;
 }


### PR DESCRIPTION
Instead of simply defining the `common` library, it's now also added to gesso's `global` library dependencies to make sure it's included everywhere.