### PR TITLE
Fix #title_display invisible setting

### DIFF
--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -13,6 +13,7 @@
  */
 #}
 {% set classes = [
+  title_display == 'invisible' ? 'visually-hidden',
   required ? 'js-form-required',
 ] %}
 


### PR DESCRIPTION
Restores default Drupal behavior for invisible form element title.

Fixes duplicate titles in some form elements, like Date.

![image](https://user-images.githubusercontent.com/18591033/192476317-30d4a202-fefd-4af4-b3db-aefd9b016520.png)
