### PR TITLE
Add u-visually-hidden class if label_display is invisible

### DIFF
--- a/source/03-components/form-item/_form-item-label.twig
+++ b/source/03-components/form-item/_form-item-label.twig
@@ -6,6 +6,7 @@
   'c-form-item__label',
   is_disabled ? 'is-disabled' : '',
   is_required ? 'is-required' : '',
+  label_display == 'invisible' ? 'u-visually-hidden' : '',
   title_display == 'invisible' ? 'u-visually-hidden' : '',
   modifier_classes ? modifier_classes : '',
 ]|join(' ')|trim %}


### PR DESCRIPTION
We need to add the `u-visually-hidden` class to the form item label if the `label_display` is set to invisible.