### PR TITLE
704: Fix image alignment in CKEditor 5 when a caption is added

### DIFF
--- a/includes/media.inc
+++ b/includes/media.inc
@@ -42,6 +42,11 @@ function gesso_preprocess_filter_caption(array &$variables) {
     $variables['caption'] = ' ';
   }
 
+  // Replace alignment classes.
+  if (isset($variables['classes'])) {
+    $variables['classes'] = str_replace('align', 'u-align', $variables['classes']);
+  }
+
   $variables['node'] = FilteredMarkup::create(Html::serialize($dom));
 }
 

--- a/templates/content-edit/filter-caption.html.twig
+++ b/templates/content-edit/filter-caption.html.twig
@@ -22,6 +22,7 @@
   align == 'center' ? 'u-align-center',
   align == 'left' ? 'u-align-left',
   align == 'right' ? 'u-align-right',
+  classes,
 ]|join(' ')|trim %}
 
 {% include '@components/figure/figure.twig' with {


### PR DESCRIPTION
Fixes #704.

This fix is primarily for the default CKEditor image embed plugin, and doesn’t interfere with our usual approach of embedding images via the Media module.