### PR TITLE
fixes typo in description attributes

### DIFF
--- a/source/03-components/dropbutton/dropbutton.twig
+++ b/source/03-components/dropbutton/dropbutton.twig
@@ -10,9 +10,9 @@
 <div {{ add_attributes({class: classes}) }}>
   <ul class="c-dropbutton__list js-dropbutton-list">
     {%- for item in links -%}
-    <li {{ add_attributes({class: "c-dropbutton__item"}, 'item.attributes') }}>
+    <li {{ add_attributes({class: "c-dropbutton__item"}, 'item_attributes') }}>
       {%- if item.link -%}
-        <a {{ add_attributes({class: 'c-button c-dropbutton__button'}, 'item.link.attributes') }}{% if item.href %} href={{ item.href }}{% endif %}>
+        <a {{ add_attributes({class: 'c-button c-dropbutton__button'}, 'item_link_attributes') }}{% if item.href %} href={{ item.href }}{% endif %}>
           {{ item.text }}
         </a>
       {%- elseif item.text_attributes -%}

--- a/source/03-components/fieldset/fieldset.twig
+++ b/source/03-components/fieldset/fieldset.twig
@@ -40,8 +40,8 @@
 
 <fieldset {{ add_attributes(attributes_to_add) }}>
   {#  Always wrap fieldset legends in a <span> for CSS positioning. #}
-  <legend {{ add_attributes({class: 'c-fieldset__legend'}, 'legend.attributes') }}>
-    <span {{ add_attributes({class: legend_span_classes}, 'legend_span.attributes') }}>{{ legend.title }}</span>
+  <legend {{ add_attributes({class: 'c-fieldset__legend'}, 'legend_attributes') }}>
+    <span {{ add_attributes({class: legend_span_classes}, 'legend_span_attributes') }}>{{ legend.title }}</span>
   </legend>
   <div class="c-fieldset__content">
     {% if errors %}

--- a/source/03-components/fieldset/fieldset.twig
+++ b/source/03-components/fieldset/fieldset.twig
@@ -59,7 +59,7 @@
     {% endif %}
 
     {% if description.content %}
-      <div {{ add_attributes({class: 'c-fieldset__description', id: id}, 'description.attributes') }}>{{ description.content }}</div>
+      <div {{ add_attributes({class: 'c-fieldset__description', id: id}, 'description_attributes') }}>{{ description.content }}</div>
     {% endif %}
   </div>
 </fieldset>

--- a/source/03-components/form-item/form-item.twig
+++ b/source/03-components/form-item/form-item.twig
@@ -42,7 +42,7 @@
       {% endif %}
 
       {% if description_display == 'before' and description.content %}
-        <div {{ add_attributes(description_attributes_to_add, 'description.attributes') }}>
+        <div {{ add_attributes(description_attributes_to_add, 'description_attributes') }}>
           {{ description.content }}
         </div>
       {% endif %}
@@ -69,7 +69,7 @@
   {% endif %}
 
   {% if description_display in ['after', 'invisible'] and description.content %}
-    <div {{ add_attributes(description_attributes_to_add, 'description.attributes') }}>
+    <div {{ add_attributes(description_attributes_to_add, 'description_attributes') }}>
       {{ description.content }}
     </div>
   {% endif %}

--- a/source/03-components/view/views-view-list/views-view-list.twig
+++ b/source/03-components/view/views-view-list/views-view-list.twig
@@ -18,11 +18,11 @@
   <{{ title_element ?: 'h3' }} {{ add_attributes({ 'class': title_classes }, 'title_attributes') }}>{{ title }}</{{ title_element ?: 'h3' }}>
 {% endif %}
 
-  <{{ list.type }} {{ add_attributes({ 'class': list_classes }, 'list.attributes') }}>
+  <{{ list.type }} {{ add_attributes({ 'class': list_classes }, 'list_attributes') }}>
 
 
     {% for row in rows %}
-      <li {{ add_attributes({ 'class': item_classes }, 'row.attributes') }}>
+      <li {{ add_attributes({ 'class': item_classes }, 'row_attributes') }}>
         {{- row.content -}}
       </li>
     {% endfor %}

--- a/source/03-components/view/views-view-unformatted/views-view-unformatted.twig
+++ b/source/03-components/view/views-view-unformatted/views-view-unformatted.twig
@@ -19,7 +19,7 @@
   {% if hide_row_wrapper %}
     {{ row.content }}
   {% else %}
-    <{{ element ?: 'div' }} {{ add_attributes({ 'class': row_classes }, 'row.attributes') }}>
+    <{{ element ?: 'div' }} {{ add_attributes({ 'class': row_classes }, 'row_attributes') }}>
       {{- row.content -}}
     </{{ element ?: 'div' }}>
   {% endif %}


### PR DESCRIPTION
There's a typo in the variable name in the add_attributes calls in this file that causes Drupal to crash. This fixes it.