### PR TITLE
Add scrollbar width custom property

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -9,6 +9,7 @@ import './stubs/drupal';
 import './stubs/once';
 
 import '../dist/css/styles.css';
+import '../dist/js/universal.es6.js';
 
 function setupTwig(twig) {
   twig.cache();

--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -4,6 +4,8 @@ global:
       # If you alter the fonts here, be sure to also update: source/ckeditor4-styles.scss, source/editor-styles.scss and .storybook/preview-head.html.
       //fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap: { type: external }
       dist/css/styles.css: {}
+  js:
+    dist/js/universal.es6.js: {}
 
 accordion:
   header: true

--- a/source/00-config/mixins/_layout.scss
+++ b/source/00-config/mixins/_layout.scss
@@ -58,10 +58,13 @@
 @mixin layout-full-bleed() {
   left: 50%;
   margin-left: -50vw;
+  margin-left: calc(-50vw + var(--scrollbar-width) / 2);
   margin-right: -50vw;
+  margin-right: calc(-50vw + var(--scrollbar-width) / 2);
   position: relative;
   right: 50%;
   width: 100vw;
+  width: calc(100vw - var(--scrollbar-width));
 }
 
 // Reverses the above.

--- a/source/00-config/mixins/_layout.scss
+++ b/source/00-config/mixins/_layout.scss
@@ -33,6 +33,7 @@
   margin-left: auto;
   margin-right: auto;
   max-width: rem($max-width);
+  width: 100%;
 
   @if $margins-mobile {
     padding-left: rem($margins-mobile);

--- a/source/00-config/mixins/_layout.scss
+++ b/source/00-config/mixins/_layout.scss
@@ -58,13 +58,10 @@
 // and makes it flush with the edge of the viewport.
 @mixin layout-full-bleed() {
   left: 50%;
-  margin-left: -50vw;
   margin-left: calc(-50vw + var(--scrollbar-width) / 2);
-  margin-right: -50vw;
   margin-right: calc(-50vw + var(--scrollbar-width) / 2);
   position: relative;
   right: 50%;
-  width: 100vw;
   width: calc(100vw - var(--scrollbar-width));
 }
 

--- a/source/01-global/html-elements/00-universal/_universal.scss
+++ b/source/01-global/html-elements/00-universal/_universal.scss
@@ -2,6 +2,11 @@
 
 @use '00-config' as *;
 
+:root {
+  // stylelint-disable-next-line
+  --scrollbar-width: 0px;
+}
+
 // Uncomment to add a set of default transitions to all elements
 // * {
 //   transition-duration: gesso-duration(short);
@@ -23,6 +28,7 @@
     color: #000 !important;
     text-shadow: none !important;
   }
+
   @page {
     margin: 2cm;
   }

--- a/source/01-global/html-elements/00-universal/universal.es6.js
+++ b/source/01-global/html-elements/00-universal/universal.es6.js
@@ -1,0 +1,8 @@
+import Drupal from 'drupal';
+import setScrollbarProperty from '../../../06-utility/_setScrollbarProperty.es6';
+
+Drupal.behaviors.setScrollbarProperty = {
+  attach() {
+    setScrollbarProperty();
+  },
+};

--- a/source/06-utility/_setScrollbarProperty.es6.js
+++ b/source/06-utility/_setScrollbarProperty.es6.js
@@ -1,0 +1,30 @@
+/**
+ * Calculate the width of the vertical scrollbar.
+ * via https://codepen.io/Mamboleoo/post/scrollbars-and-css-custom-properties
+ */
+ function calculateScrollbarSize() {
+  const containerWithScroll = document.createElement('div');
+  containerWithScroll.style.visibility = 'hidden';
+  containerWithScroll.style.overflow = 'scroll';
+  const innerContainer = document.createElement('div');
+  containerWithScroll.appendChild(innerContainer);
+  document.body.appendChild(containerWithScroll);
+  const width = containerWithScroll.offsetWidth - innerContainer.offsetWidth;
+  document.body.removeChild(containerWithScroll);
+  return width;
+}
+
+/**
+ * Set a CSS variable with the width of the scrollbar.
+ */
+function setScrollbarProperty() {
+  const scrollbarWidth = calculateScrollbarSize();
+  if (!Number.isNaN(scrollbarWidth)) {
+    document.documentElement.style.setProperty(
+      '--scrollbar-width',
+      `${scrollbarWidth}px`
+    );
+  }
+}
+
+export default setScrollbarProperty;


### PR DESCRIPTION
This PR updates the full-bleed layout mixin to account for the browser’s scrollbar width. It also updates the layout-constrain mixin to handle edge cases where the element doesn’t try to fill its available space.

h/t to @kmonahan who initially did this work.