### PR TITLE
Fix page template when viewing node revisions

### DIFF
--- a/templates/layout/page--node--revisions--view.html.twig
+++ b/templates/layout/page--node--revisions--view.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - messages: Status and error messages. Should be displayed prominently.
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.header: Items for the header region.
+ * - page.navigation: Items for the navigation region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.preface: Items for the preface content region.
+ * - page.title: page title .
+ * - page.status: Status messages and local tasks.
+ * - page.content: The main content of the current page.
+ * - page.postscript: Items for the postscript content region.
+ * - page.footer: Items for the footer region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+{% extends "page--node--%.html.twig" %}


### PR DESCRIPTION
This PR fixes the page template when viewing node revisions. Previously, you would see the page title and status messages displayed twice.