### PR TITLE
adds focus for radio items

### DIFF
--- a/source/03-components/form-item/form-item--radio/_form-item--radio.scss
+++ b/source/03-components/form-item/form-item--radio/_form-item--radio.scss
@@ -9,7 +9,6 @@
   }
 
   .c-form-item__radio {
-    @include focus();
     appearance: none;
     background-color: gesso-color(form, background-unchecked);
     border: 1px solid gesso-color(form, border-dark);
@@ -30,6 +29,10 @@
       background-color: gesso-color(form, background-checked);
       border: 2px solid gesso-color(form, background-unchecked);
       box-shadow: 0 0 0 2px gesso-color(form, background-checked);
+    }
+
+    &:focus-visible {
+      @include focus();
     }
 
     &:disabled {

--- a/source/03-components/form-item/form-item--radio/_form-item--radio.scss
+++ b/source/03-components/form-item/form-item--radio/_form-item--radio.scss
@@ -9,6 +9,7 @@
   }
 
   .c-form-item__radio {
+    @include focus();
     appearance: none;
     background-color: gesso-color(form, background-unchecked);
     border: 1px solid gesso-color(form, border-dark);
@@ -17,7 +18,6 @@
     cursor: pointer;
     height: 18px;
     margin-right: 3px;
-    outline: none;
     position: relative;
     top: 2px;
     transition-duration: gesso-duration(short);
@@ -29,10 +29,6 @@
       background-color: gesso-color(form, background-checked);
       border: 2px solid gesso-color(form, background-unchecked);
       box-shadow: 0 0 0 2px gesso-color(form, background-checked);
-    }
-
-    &:focus-visible {
-      @include focus();
     }
 
     &:disabled {


### PR DESCRIPTION
Ran into this on a project. Radio items can individually be navigated with up/down arrow keys, but when tabbing through a form there is no focus state to indicate that you're inside the list of radio items. This fixes that, adding a focus state around the first item if none is selected when you tab to them.