### PR TITLE
adds base font properties from the HTML tag to ckeditor5 content

### DIFF
--- a/source/editor-styles.scss
+++ b/source/editor-styles.scss
@@ -8,6 +8,15 @@
 // stylelint-disable selector-class-pattern
 div.paragraph--view-mode--preview,
 div.ck-content {
+  // Ensuring font properties from source/01-global/html-elements/01-html/_html.scss
+  // get applied to CKEditor content. This may need to updated to match any
+  // font customizations made to the HTML or BODY element.
+  font-family: gesso-font-family(primary);
+  line-height: gesso-line-height(base);
+}
+
+div.paragraph--view-mode--preview,
+div.ck-content {
   @include meta.load-css('01-global', $with: ('wysiwyg': true));
   @include meta.load-css('02-layouts', $with: ('wysiwyg': true));
   @include meta.load-css('03-components', $with: ('wysiwyg': true));


### PR DESCRIPTION
Since CKEditor5 is not in an iframe, any styles applied directly to the BODY or HTML tag do not carry through to the WYSIWYG since those tags don't exist inside the editor. Other element's CSS (headings, lists, etc.) work fine, but the base font properties we typically apply to the HTML tag do not get applied to things like a plain `<p>` tag. This PR addresses that by applying the basic font properties directly to the editor container. 

If this seems hacky, a cleaner approach might be to use a placeholder or mixin... but it seemed like overkill as I started to go down that path.  I'm open to suggestion though if anyone has a more elegant suggestion for how to do this or thinks a mixin or something would be better.
