### PR TITLE
Update alignment classes

### DIFF
--- a/gesso.info.yml
+++ b/gesso.info.yml
@@ -8,6 +8,12 @@ libraries:
   - gesso/global
 libraries-override:
   core/drupal.dropbutton: gesso/dropbutton
+  system/base:
+    css:
+      component:
+        css/components/align.module.css: false
+        css/components/clearfix.module.css: false
+        css/components/hidden.module.css: false
 ckeditor_stylesheets:
   - dist/css/ckeditor4-styles.css
 ckeditor5-stylesheets:

--- a/source/06-utility/_alignment.scss
+++ b/source/06-utility/_alignment.scss
@@ -3,26 +3,48 @@
 @use '00-config' as *;
 
 // Align items
-.u-align-left,
-.align-left {
+.align-left,
+.u-align-left {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: left;
     margin-right: rem(gesso-get-map(gutter-width));
   }
 }
 
-.u-align-right,
-.align-right {
+.align-right,
+.u-align-right {
   @include breakpoint(gesso-breakpoint(tablet)) {
     float: right;
     margin-left: rem(gesso-get-map(gutter-width));
   }
 }
 
-.u-align-center,
-.align-center {
+.align-center,
+.u-align-center {
+  display: block;
   margin-left: auto;
   margin-right: auto;
+}
+
+// Text alignment
+.text-align-left,
+.u-text-align-left {
+  text-align: left;
+}
+
+.text-align-right,
+.u-text-align-right {
+  text-align: right;
+}
+
+.text-align-center,
+.u-text-align-center {
+  text-align: center;
+}
+
+.text-align-justify,
+.u-text-align-justify {
+  text-align: justify;
 }
 
 // Clear floats


### PR DESCRIPTION
This PR:

- Adds text alignment utility classes
- Reorders alignment selectors to match other utility partials
- Prevents Drupal from loading unnecessary style sheets (styles that Gesso already handles)