### PR TITLE
adds drupal classes and wrapper around radios and checkboxes

### DIFF
--- a/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
+++ b/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
@@ -3,4 +3,4 @@
   'c-form-item--checkboxes',
 ]|join(' ')|trim %}
 
-<div{{ attributes.addClass(classes) }}>{{ children }}</div>
+<div {{ add_attributes({ 'class': classes }) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
+++ b/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
@@ -1,6 +1,6 @@
 {% set classes = [
   'c-form-item',
   'c-form-item--checkboxes',
-] %}
+]|join(' ')|trim %}
 
 <div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
+++ b/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
@@ -1,8 +1,6 @@
-{# 'form-checkboxes' is a Drupal core class used by some modules (e.g., webform) #}
 {% set classes = [
   'c-form-item',
   'c-form-item--checkboxes',
-  'form-checkboxes',
 ] %}
 
 <div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
+++ b/source/03-components/form-item/form-item--checkboxes/form-item--checkboxes.twig
@@ -1,1 +1,8 @@
-{{ children }}
+{# 'form-checkboxes' is a Drupal core class used by some modules (e.g., webform) #}
+{% set classes = [
+  'c-form-item',
+  'c-form-item--checkboxes',
+  'form-checkboxes',
+] %}
+
+<div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--radios/form-item--radios.twig
+++ b/source/03-components/form-item/form-item--radios/form-item--radios.twig
@@ -1,1 +1,8 @@
-{{ children }}
+{# 'form-radios' is a Drupal core class used by some modules (e.g., webform) #}
+{% set classes = [
+  'c-form-item',
+  'c-form-item--radios',
+  'form-radios',
+] %}
+
+<div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--radios/form-item--radios.twig
+++ b/source/03-components/form-item/form-item--radios/form-item--radios.twig
@@ -1,8 +1,6 @@
-{# 'form-radios' is a Drupal core class used by some modules (e.g., webform) #}
 {% set classes = [
   'c-form-item',
   'c-form-item--radios',
-  'form-radios',
 ] %}
 
 <div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--radios/form-item--radios.twig
+++ b/source/03-components/form-item/form-item--radios/form-item--radios.twig
@@ -1,6 +1,6 @@
 {% set classes = [
   'c-form-item',
   'c-form-item--radios',
-] %}
+]|join(' ')|trim %}
 
 <div{{ attributes.addClass(classes) }}>{{ children }}</div>

--- a/source/03-components/form-item/form-item--radios/form-item--radios.twig
+++ b/source/03-components/form-item/form-item--radios/form-item--radios.twig
@@ -3,4 +3,4 @@
   'c-form-item--radios',
 ]|join(' ')|trim %}
 
-<div{{ attributes.addClass(classes) }}>{{ children }}</div>
+<div {{ add_attributes({ 'class': classes }) }}>{{ children }}</div>

--- a/templates/form/checkboxes.html.twig
+++ b/templates/form/checkboxes.html.twig
@@ -10,4 +10,8 @@
  * @see template_preprocess_checkboxes()
  */
 #}
+
+{# 'form-checkboxes' is a Drupal core class used by some modules (e.g., webform) #}
+{% set attributes = attributes.addClass('form-checkboxes') %}
+
 {% include '@components/form-item/form-item--checkboxes/form-item--checkboxes.twig' %}

--- a/templates/form/radios.html.twig
+++ b/templates/form/radios.html.twig
@@ -10,4 +10,8 @@
  * @see template_preprocess_radios()
  */
 #}
+
+{# 'form-radios' is a Drupal core class used by some modules (e.g., webform) #}
+{% set attributes = attributes.addClass('form-radios') %}
+
 {% include '@components/form-item/form-item--radios/form-item--radios.twig' %}

--- a/templates/form/radios.html.twig
+++ b/templates/form/radios.html.twig
@@ -10,9 +10,4 @@
  * @see template_preprocess_radios()
  */
 #}
-{% set classes = [
-  'c-form-item',
-  'c-form-item--radios',
-] %}
-
-<div{{ attributes.addClass(classes) }}>{{ children }}</div>
+{% include '@components/form-item/form-item--radios/form-item--radios.twig' %}


### PR DESCRIPTION
This adds the wrapper and default Drupal classes around radios and checkboxes, similar to how they are in the core theme templates.  Without these classes/wrappers we found that error messages appear in odd locations (at least when using the webform module), such as right under the label for the first checkbox in a list of checkboxes instead of below all of them.  

