### PR TITLE
Added Accordion and WYSIWYG paragraph templates for f1 modules

### DIFF
--- a/templates/paragraph/paragraph--accordion-item.html.twig
+++ b/templates/paragraph/paragraph--accordion-item.html.twig
@@ -1,0 +1,5 @@
+{% include "@components/accordion/accordion-item.twig" with {
+  title_element: 'h3',
+  title: content.field_accordion_heading|field_value,
+  content: content.field_accordion_body|field_value,
+}%}

--- a/templates/paragraph/paragraph--accordion-item.html.twig
+++ b/templates/paragraph/paragraph--accordion-item.html.twig
@@ -1,5 +1,6 @@
 {% include "@components/accordion/accordion-item.twig" with {
-  title_element: 'h3',
-  title: content.field_accordion_heading|field_value is not empty ? content.field_accordion_heading|field_value : false,
-  content: content.field_accordion_body|field_value is not empty ? content.field_accordion_body|field_value : false,
+  'modifier_classes': '',
+  'title_element': 'h3',
+  'title': content.field_accordion_heading|field_value is not empty ? content.field_accordion_heading|field_value : false,
+  'content': content.field_accordion_body|field_value is not empty ? content.field_accordion_body|field_value : false,
 }%}

--- a/templates/paragraph/paragraph--accordion-item.html.twig
+++ b/templates/paragraph/paragraph--accordion-item.html.twig
@@ -1,4 +1,4 @@
-{% include "@components/accordion/accordion-item.twig" with {
+{% include '@components/accordion/accordion-item.twig' with {
   'modifier_classes': '',
   'title_element': 'h3',
   'title': content.field_accordion_heading|field_value is not empty ? content.field_accordion_heading|field_value : false,

--- a/templates/paragraph/paragraph--accordion-item.html.twig
+++ b/templates/paragraph/paragraph--accordion-item.html.twig
@@ -1,5 +1,5 @@
 {% include "@components/accordion/accordion-item.twig" with {
   title_element: 'h3',
-  title: content.field_accordion_heading|field_value,
-  content: content.field_accordion_body|field_value,
+  title: content.field_accordion_heading|field_value is not empty ? content.field_accordion_heading|field_value : false,
+  content: content.field_accordion_body|field_value is not empty ? content.field_accordion_body|field_value : false,
 }%}

--- a/templates/paragraph/paragraph--accordion.html.twig
+++ b/templates/paragraph/paragraph--accordion.html.twig
@@ -1,6 +1,6 @@
 {% include "@components/accordion/accordion.twig" with {
-  modifier_classes: '',
-  has_constrain: true,
-  allow_multiple: true,
-  accordion_items: content.field_accordion_items|field_value is not empty ? content.field_accordion_items|field_value : false,
+  'modifier_classes': '',
+  'has_constrain': true,
+  'allow_multiple': true,
+  'accordion_items': content.field_accordion_items|field_value is not empty ? content.field_accordion_items|field_value : false,
 }%}

--- a/templates/paragraph/paragraph--accordion.html.twig
+++ b/templates/paragraph/paragraph--accordion.html.twig
@@ -1,4 +1,4 @@
-{% include "@components/accordion/accordion.twig" with {
+{% include '@components/accordion/accordion.twig' with {
   'modifier_classes': '',
   'has_constrain': true,
   'allow_multiple': true,

--- a/templates/paragraph/paragraph--accordion.html.twig
+++ b/templates/paragraph/paragraph--accordion.html.twig
@@ -1,0 +1,8 @@
+{{ attach_library('gesso/accordion') }}
+
+{% include "@components/accordion/accordion.twig" with {
+  modifier_classes: '',
+  has_constrain: true,
+  allow_multiple: true,
+  accordion_items: content.field_accordion_items|field_value,
+}%}

--- a/templates/paragraph/paragraph--accordion.html.twig
+++ b/templates/paragraph/paragraph--accordion.html.twig
@@ -1,8 +1,6 @@
-{{ attach_library('gesso/accordion') }}
-
 {% include "@components/accordion/accordion.twig" with {
   modifier_classes: '',
   has_constrain: true,
   allow_multiple: true,
-  accordion_items: content.field_accordion_items|field_value,
+  accordion_items: content.field_accordion_items|field_value is not empty ? content.field_accordion_items|field_value : false,
 }%}

--- a/templates/paragraph/paragraph--wysiwyg.html.twig
+++ b/templates/paragraph/paragraph--wysiwyg.html.twig
@@ -1,4 +1,4 @@
-{% include "@components/wysiwyg/wysiwyg.twig" with {
+{% include '@components/wysiwyg/wysiwyg.twig' with {
   'modifier_classes': '',
   'content': content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
 }%}

--- a/templates/paragraph/paragraph--wysiwyg.html.twig
+++ b/templates/paragraph/paragraph--wysiwyg.html.twig
@@ -1,0 +1,4 @@
+{% include "@components/wysiwyg/wysiwyg.twig" with {
+  modifier_classes: '',
+  content: content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
+}%}

--- a/templates/paragraph/paragraph--wysiwyg.html.twig
+++ b/templates/paragraph/paragraph--wysiwyg.html.twig
@@ -1,4 +1,4 @@
 {% include "@components/wysiwyg/wysiwyg.twig" with {
-  modifier_classes: '',
-  content: content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
+  'modifier_classes': '',
+  'content': content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
 }%}


### PR DESCRIPTION
See [corresponding PR](https://github.com/forumone/drupal-project/pull/88) in the drupal-project

@coreylafferty I'm not sure if it's appropriate to leverage `|field_value` for these field values, so please advise whether those should be kept or removed. I've added `twig_tweak` as a dependency in the corresponding Drupal module. 