### PR TITLE
updated stories to not show unpublished by default and always load assets

### DIFF
--- a/source/00-config/storybook.global-data.yml
+++ b/source/00-config/storybook.global-data.yml
@@ -8,6 +8,7 @@ site_slogan: 'This is the site slogan.'
 section: 'Section'
 page_title: 'Page Title'
 title: 'Title'
+is_published: true
 show_admin_info: false
 summary: '<p>This is the summary, which can contain <abbr title="Hyper Text Markup Language">HTML</abbr> markup. It should be 600 characters or less.</p>'
 author_name: 'Author Name'

--- a/source/04-templates/homepage/homepage.stories.jsx
+++ b/source/04-templates/homepage/homepage.stories.jsx
@@ -7,7 +7,10 @@ import twigTemplate from './homepage.twig';
 import globalData from '../../00-config/storybook.global-data.yml';
 import ContentPlaceholder from '../../01-global/content-placeholder/content-placeholder';
 import { HeroImage } from '../../01-global/images/hero-image.stories.jsx';
-import '../../03-components/hero-bg-image/hero-bg-image.scss';
+// Importing components to ensure their assets get loaded in Storybook when they
+// get referenced since Drupal loads them as a library.
+import { Default as HeroBGImage } from '../../03-components/hero-bg-image/hero-bg-image.stories.jsx';
+import { Default as Message } from '../../03-components/message/message.stories.jsx';
 
 const settings = {
   title: 'Templates/Homepage',

--- a/source/04-templates/landing-page/landing-page.stories.jsx
+++ b/source/04-templates/landing-page/landing-page.stories.jsx
@@ -6,6 +6,9 @@ import { withGlobalWrapper } from '../../../.storybook/decorators';
 import twigTemplate from './landing-page.twig';
 import globalData from '../../00-config/storybook.global-data.yml';
 import ContentPlaceholder from '../../01-global/content-placeholder/content-placeholder';
+// Importing components to ensure their assets get loaded in Storybook when they
+// get referenced since Drupal loads them as a library.
+import { Default as Message } from '../../03-components/message/message.stories.jsx';
 
 const settings = {
   title: 'Templates/Landing Page',

--- a/source/04-templates/page/page.stories.jsx
+++ b/source/04-templates/page/page.stories.jsx
@@ -6,6 +6,9 @@ import { withGlobalWrapper } from '../../../.storybook/decorators';
 import twigTemplate from './page.twig';
 import globalData from '../../00-config/storybook.global-data.yml';
 import ContentPlaceholder from '../../01-global/content-placeholder/content-placeholder';
+// Importing components to ensure their assets get loaded in Storybook when they
+// get referenced since Drupal loads them as a library.
+import { Article } from '../../03-components/article/article.stories.jsx';
 
 const settings = {
   title: 'Templates/Page',

--- a/source/05-pages/article.stories.jsx
+++ b/source/05-pages/article.stories.jsx
@@ -4,7 +4,7 @@ import parse from 'html-react-parser';
 
 import globalData from '../00-config/storybook.global-data.yml';
 import PageWrapper from './page-wrappers/default.jsx';
-import twigTemplate from '../04-templates/page/page.twig';
+import { Page as Template } from '../04-templates/page/page.stories.jsx';
 import { FigureRightAligned } from '../03-components/figure/figure.stories.jsx';
 
 export default {
@@ -52,23 +52,25 @@ const articleDemoContent = `
 // For an example of customizing the content block on a demo page,
 // see Page.
 const articleContent = args =>
-  twigTemplate({
-    ...args,
-    title: 'As You Wish',
-    show_footer: true,
-    date_format: 'medium-date',
-    year: {
-      long: '1987',
-    },
-    month: {
-      long: 'October',
-    },
-    day: {
-      short: '9',
-    },
-    author_name: 'William Goldman',
-    content: articleDemoContent,
-  });
+  ReactDOMServer.renderToStaticMarkup(
+    Template.render({
+      ...args,
+      title: 'As You Wish',
+      show_footer: true,
+      date_format: 'medium-date',
+      year: {
+        long: '1987',
+      },
+      month: {
+        long: 'October',
+      },
+      day: {
+        short: '9',
+      },
+      author_name: 'William Goldman',
+      content: articleDemoContent,
+    })
+  );
 
 const Article = {
   render: args => <PageWrapper>{parse(articleContent(args))}</PageWrapper>,

--- a/source/05-pages/homepage.stories.jsx
+++ b/source/05-pages/homepage.stories.jsx
@@ -4,7 +4,7 @@ import parse from 'html-react-parser';
 
 import globalData from '../00-config/storybook.global-data.yml';
 import PageWrapper from './page-wrappers/default.jsx';
-import twigTemplate from '../04-templates/homepage/homepage.twig';
+import { Homepage as Template } from '../04-templates/homepage/homepage.stories.jsx';
 import { Default as HeroBgImage } from '../03-components/hero-bg-image/hero-bg-image.stories.jsx';
 import { Default as Card } from '../03-components/card/card.stories.jsx';
 
@@ -47,16 +47,19 @@ const homepageGridContent = [
 ];
 
 const homepageContent = args =>
-  twigTemplate({
-    ...args,
-    homepage_hero: ReactDOMServer.renderToStaticMarkup(
-      HeroBgImage.render(HeroBgImage.args)
-    ),
-    homepage_grid_content: ReactDOMServer.renderToStaticMarkup(
-      homepageGridContent.map(card => card)
-    ),
-    homepage_grid_title: 'You Don’t Vote For Kings',
-  });
+  ReactDOMServer.renderToStaticMarkup(
+    Template.render({
+      ...args,
+      homepage_hero: ReactDOMServer.renderToStaticMarkup(
+        HeroBgImage.render(HeroBgImage.args)
+      ),
+      homepage_grid_content: ReactDOMServer.renderToStaticMarkup(
+        homepageGridContent.map(card => card)
+      ),
+      homepage_grid_title: 'You Don’t Vote For Kings',
+    })
+  );
+
 
 const Homepage = {
   render: args => <PageWrapper isHomepage>{parse(homepageContent(args))}</PageWrapper>,

--- a/source/05-pages/landing-page.stories.jsx
+++ b/source/05-pages/landing-page.stories.jsx
@@ -4,7 +4,7 @@ import parse from 'html-react-parser';
 
 import globalData from '../00-config/storybook.global-data.yml';
 import PageWrapper from './page-wrappers/default.jsx';
-import twigTemplate from '../04-templates/landing-page/landing-page.twig';
+import { LandingPage as Template } from '../04-templates/landing-page/landing-page.stories.jsx';
 import { Default as Card } from '../03-components/card/card.stories.jsx';
 import { View } from '../03-components/view/views-view/views-view.stories.jsx';
 import { Unformatted } from '../03-components/view/views-view-unformatted/views-view-unformatted.stories';
@@ -49,11 +49,13 @@ const mainContent = View({
 });
 
 const landingPageContent = args =>
-  twigTemplate({
-    ...args,
-    page_title: 'Great Scott!',
-    content: ReactDOMServer.renderToStaticMarkup(mainContent),
-  });
+  ReactDOMServer.renderToStaticMarkup(
+    Template.render({
+      ...args,
+      page_title: 'Great Scott!',
+      content: ReactDOMServer.renderToStaticMarkup(mainContent),
+    })
+  );
 
 const LandingPage = {
   render: args => <PageWrapper>{parse(landingPageContent(args))}</PageWrapper>,

--- a/source/05-pages/page.stories.jsx
+++ b/source/05-pages/page.stories.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import ReactDOMServer from 'react-dom/server';
 import parse from 'html-react-parser';
 
 import globalData from '../00-config/storybook.global-data.yml';
 import PageWrapper from './page-wrappers/default.jsx';
-import twigTemplate from '../04-templates/page/page.twig';
+import { Page as Template } from '../04-templates/page/page.stories.jsx';
 
 export default {
   title: 'Pages/Page',
@@ -16,10 +17,12 @@ export default {
 
 // For an example of customizing the content on a demo page, see Article page.
 const pageContent = args =>
-  twigTemplate({
-    ...args,
-    title: 'Page Title',
-  });
+  ReactDOMServer.renderToStaticMarkup(
+    Template.render({
+      ...args,
+      title: 'Page Title',
+    })
+  );
 
 const Page = {
   render: args => <PageWrapper>{parse(pageContent(args))}</PageWrapper>,


### PR DESCRIPTION
@dcmouyard @kmonahan As I was testing this I noticed that:

- In Storybook, the unpublished message displayed everywhere by default
- Unless you'd already clicked on a story within Storybook that loaded the message CSS, the unpublished message was unstyled on templates/pages. This is actually true of the admin controls as well, even in the current release.

To address these issues I've: 

1. Set a global variable to set things in Storybook to published (similar to how we've hidden the admin controls) so you have to manually click to show the unpublished indicator. 
2. Refactored how we're loading things in the templates/pages, loading any necessary stories in templates that might contain styling or JS if we're including them in Twig even if we're not directly referencing them as stories and switching from only loading the Twig file in page files to loading the entire template story to ensure all assets get loaded.

Can you look over these changes and see if anything jumps out as problematic? If not I'm going to roll out this approach to the other Gesso flavors as well.  Thanks!