### PR TITLE
788: Line-height and letter-spacing design tokens

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -139,10 +139,6 @@ function getScalarVisitor(path) {
   ) {
     const prefix = path[4];
 
-    if (prefix === 'letter-spacing') {
-      return identityTransformer;
-    }
-
     if (prefix === 'font-style') {
       return identityTransformer;
     }

--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -266,33 +266,33 @@ gesso:
       semibold: 600
       bold: 700
     line-height:
-      tight: 1.1
+      short: 1.1
       base: 1.45
-      loose: 1.7
+      tall: 1.7
     display:
       display:
         color: text.primary
         font-family: primary.stack
         font-weight: bold
-        line-height: tight
+        line-height: short
         responsive-font-size: 15
       h1:
         color: text.primary
         font-family: primary.stack
         font-weight: bold
-        line-height: tight
+        line-height: short
         responsive-font-size: 12
       h2:
         color: text.primary
         font-family: primary.stack
         font-weight: bold
-        line-height: tight
+        line-height: short
         responsive-font-size: 10
       h3:
         color: text.primary
         font-family: primary.stack
         font-weight: bold
-        line-height: tight
+        line-height: short
         responsive-font-size: 8
       h4:
         color: text.primary
@@ -311,7 +311,7 @@ gesso:
         font-family: primary.stack
         font-weight: semibold
         letter-spacing: -0.04em
-        line-height: loose
+        line-height: tall
         text-transform: uppercase
         responsive-font-size: 2
       blockquote:
@@ -339,7 +339,7 @@ gesso:
         font-style: normal
         font-weight: semibold
         letter-spacing: .02em
-        line-height: tight
+        line-height: short
   transitions:
     ease:
       ease-in-out: 'cubic-bezier(0.4, 0, 0.2, 1)'

--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -265,6 +265,10 @@ gesso:
       regular: 400
       semibold: 600
       bold: 700
+    letter-spacing:
+      tight: -0.04em
+      normal: 0
+      wide: 0.02em
     line-height:
       short: 1.1
       base: 1.45
@@ -310,7 +314,7 @@ gesso:
         color: text.primary
         font-family: primary.stack
         font-weight: semibold
-        letter-spacing: -0.04em
+        letter-spacing: tight
         line-height: tall
         text-transform: uppercase
         responsive-font-size: 2
@@ -338,7 +342,7 @@ gesso:
         font-size: 2
         font-style: normal
         font-weight: semibold
-        letter-spacing: .02em
+        letter-spacing: wide
         line-height: short
   transitions:
     ease:

--- a/source/00-config/functions/_gesso.scss
+++ b/source/00-config/functions/_gesso.scss
@@ -75,6 +75,11 @@
   @return gesso-get-map(typography, font-weight, $keys...);
 }
 
+// Get Letter Spacing
+@function gesso-letter-spacing($keys...) {
+  @return gesso-get-map(typography, letter-spacing, $keys...);
+}
+
 // Get Line Height
 @function gesso-line-height($keys...) {
   @return gesso-get-map(typography, line-height, $keys...);

--- a/source/01-global/01-typography/letter-spacing.scss
+++ b/source/01-global/01-typography/letter-spacing.scss
@@ -1,0 +1,27 @@
+// Storybook: Line Height
+
+@use '00-config' as *;
+
+.gesso-storybook-letter-spacing {
+  margin: 0 0 3rem;
+}
+
+.gesso-storybook-letter-spacing__heading {
+  font-family: gesso-font-family(system);
+  font-size: 1.25rem;
+  line-height: 1.25;
+  margin-bottom: 1rem;
+}
+
+.gesso-storybook-letter-spacing__row {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  line-height: 1;
+  margin: 1rem 0;
+}
+
+.gesso-storybook-letter-spacing__label {
+  font-family: gesso-font-family(system);
+  font-weight: bold;
+}

--- a/source/01-global/01-typography/letter-spacing.stories.jsx
+++ b/source/01-global/01-typography/letter-spacing.stories.jsx
@@ -6,7 +6,7 @@ import data from '../../00-config/config.design-tokens.yml';
 import './letter-spacing.scss';
 
 const settings = {
-  title: 'Global/Typography/LetterSpacing',
+  title: 'Global/Typography/Letterspacing',
   decorators: [withGlobalWrapper],
   argTypes: {
     gesso: {
@@ -17,10 +17,10 @@ const settings = {
   },
 };
 
-const LetterSpacing = {
+const Letterspacing = {
   render: args => parse(twigTemplate(args)),
   args: { ...data },
 };
 
 export default settings;
-export { LetterSpacing };
+export { Letterspacing };

--- a/source/01-global/01-typography/letter-spacing.stories.jsx
+++ b/source/01-global/01-typography/letter-spacing.stories.jsx
@@ -1,0 +1,26 @@
+import parse from 'html-react-parser';
+
+import { withGlobalWrapper } from '../../../.storybook/decorators';
+import twigTemplate from './letter-spacing.twig';
+import data from '../../00-config/config.design-tokens.yml';
+import './letter-spacing.scss';
+
+const settings = {
+  title: 'Global/Typography/LetterSpacing',
+  decorators: [withGlobalWrapper],
+  argTypes: {
+    gesso: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
+
+const LetterSpacing = {
+  render: args => parse(twigTemplate(args)),
+  args: { ...data },
+};
+
+export default settings;
+export { LetterSpacing };

--- a/source/01-global/01-typography/letter-spacing.twig
+++ b/source/01-global/01-typography/letter-spacing.twig
@@ -1,0 +1,19 @@
+{% set demo_content %}
+  {% for name, value in gesso.typography['letter-spacing'] %}
+    <div class="gesso-storybook-letter-spacing__row">
+      <div class="gesso-storybook-letter-spacing__label">{{ name }}</div>
+      <div class="gesso-storybook-letter-spacing__preview" style="letter-spacing: {{ value }}">
+        The letter-spacing for this text is <strong>{{ value }}.</strong>
+      </div>
+    </div>
+  {% endfor %}
+{% endset %}
+
+{% for name, item in gesso.typography['font-family'] %}
+  <div class="gesso-storybook-letter-spacing">
+    <h2 class="gesso-storybook-letter-spacing__heading">{{ item.name }}</h2>
+    <div style='font-family: {{ item.stack }}'>
+      {{ demo_content }}
+    </div>
+  </div>
+{% endfor %}

--- a/source/01-global/01-typography/typographic-scale.scss
+++ b/source/01-global/01-typography/typographic-scale.scss
@@ -17,7 +17,7 @@
   align-items: center;
   display: flex;
   gap: 1rem;
-  line-height: gesso-line-height(tight);
+  line-height: gesso-line-height(short);
   margin: 1rem 0;
 }
 

--- a/source/03-components/dropdown-menu/dropdown-menu.scss
+++ b/source/03-components/dropdown-menu/dropdown-menu.scss
@@ -88,7 +88,7 @@
   .c-dropdown-menu__link {
     color: currentColor;
     display: block;
-    line-height: gesso-line-height(tight);
+    line-height: gesso-line-height(short);
     padding: rem(gesso-spacing(2)) calc(#{rem(gesso-spacing(3))} + 7px)
       rem(gesso-spacing(2)) rem(gesso-spacing(3));
     position: relative;

--- a/source/03-components/mega-menu/mega-menu.scss
+++ b/source/03-components/mega-menu/mega-menu.scss
@@ -214,7 +214,7 @@
   color: gesso-brand(blue, light-1);
   font-size: rem(gesso-font-size(2));
   font-weight: gesso-font-weight(semibold);
-  line-height: gesso-line-height(tight);
+  line-height: gesso-line-height(short);
   text-transform: none;
 
   &:hover {

--- a/source/03-components/skiplinks/_skiplinks.scss
+++ b/source/03-components/skiplinks/_skiplinks.scss
@@ -25,7 +25,7 @@
   color: gesso-color(text, on-dark);
   display: inline-block;
   font-weight: bold;
-  line-height: gesso-line-height(tight);
+  line-height: gesso-line-height(short);
   margin: 0;
   outline: 0;
   padding: rem(gesso-spacing(2));


### PR DESCRIPTION
Fixes #788 .

Renames line-height tokens to short, base, and tall.

Adds letter-spacing tokens: tight, normal, and wide. Also adds a `gesso-letter-spacing()` function and a demo page for letter-spacing in Storybook.