### PR TITLE
[757] Prevent fonts from being emitted multiple times

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -154,7 +154,7 @@ module.exports = {
         exclude: ['/node_modules/'],
         type: 'asset/resource',
         generator: {
-          filename: 'fonts/[hash][ext][query]',
+          filename: 'fonts/[name][ext][query]',
         },
       },
       {

--- a/webpack.react-config.js
+++ b/webpack.react-config.js
@@ -55,6 +55,14 @@ module.exports = {
           },
         ],
       },
+      {
+        test: /fonts\/.*\.(woff2?|ttf|otf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/i,
+        exclude: ['/node_modules/'],
+        type: 'asset/resource',
+        generator: {
+          filename: 'fonts/[name][ext][query]',
+        },
+      },
     ],
   },
 


### PR DESCRIPTION
Closes #757 by switching the emitted fonts to being identified by name rather than hash (which also makes /dist/fonts easier to read).

Applies to GUSWDS.