### PR TITLE
PR#797 tweak - removes separator from particular item wrapper elements for Fences

### DIFF
--- a/templates/field/field.html.twig
+++ b/templates/field/field.html.twig
@@ -42,9 +42,17 @@
   'c-field--type-' ~ field_type|clean_class,
   'c-field--label-' ~ label_display,
 ] %}
-
 {% if show_separator is null %}
-  {% set show_separator = true %}
+  {# By default, this field template comma separates values in multivalue
+    fields. This may not be desired if the Fences module is used to change
+    the field item wrapper element to a non-inline element. Add or remove
+    elements as needed from the following list to disable separators for
+    particular item wrapper elements. #}
+  {% if field_item_tag in ['li', 'dt', 'dd', 'blockquote', 'details', 'section', 'figure', 'p'] %}
+    {% set show_separator = false %}
+  {% else %}
+    {% set show_separator = true %}
+  {% endif %}
 {% endif %}
 
 {% if separator is null %}


### PR DESCRIPTION
I've added an easily modifiable list of item wrapper elements to the default field template to disable field item separation if Fences is used to switch to something where commas would be disruption.

@dcmouyard @johnbburg What do you think of these changes?