### PR TITLE
Remove React dependency warnings in Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -54,6 +54,7 @@ const config = {
                 ...swcLoaderConfig?.options?.jsc?.transform?.react,
                 development: !isProdBuild,
                 refresh: !isProdBuild,
+                runtime: 'automatic',
               },
             },
           },

--- a/source/03-components/back-to-top/back-to-top.stories.jsx
+++ b/source/03-components/back-to-top/back-to-top.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import parse from 'html-react-parser';
 
 import twigTemplate from './back-to-top.twig';

--- a/source/03-components/button/button.stories.jsx
+++ b/source/03-components/button/button.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import parse from 'html-react-parser';
 
 import { withGlobalWrapper } from '../../../.storybook/decorators';

--- a/source/03-components/icon/icon.stories.jsx
+++ b/source/03-components/icon/icon.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import parse from 'html-react-parser';
 
 import { withGlobalWrapper } from '../../../.storybook/decorators';


### PR DESCRIPTION
This PR removes the need to explicitly import React in Storybook components. More info here: https://storybook.js.org/docs/configure/compilers#the-swc-compiler-doesnt-work-with-react