### PR TITLE
No wrapper templates

### DIFF
--- a/templates/block/block--admin.html.twig
+++ b/templates/block/block--admin.html.twig
@@ -18,9 +18,15 @@
   {% endblock %}
 {% endset %}
 
+{% if logged_in and title_suffix.contextual_links %}
+  {% set hide_wrapper = false %}
+{% else %}
+  {% set hide_wrapper = true %}
+{% endif %}
+
 {% embed '@components/block/block.twig' with {
   'attributes': attributes.addClass(classes),
-  'hide_wrapper': not logged_in,
+  'hide_wrapper': hide_wrapper,
   'has_constrain': false,
   'hide_content_wrapper': true,
   'label': false,

--- a/templates/field/field--no-wrapper.html.twig
+++ b/templates/field/field--no-wrapper.html.twig
@@ -45,4 +45,4 @@
   {{- item.content -}}
 {%- endfor -%}
 
-{%- if logged_in %}</span>{% endif -%}
+{%- if logged_in and title_suffix.contextual_links %}</span>{% endif -%}

--- a/templates/media/media.html.twig
+++ b/templates/media/media.html.twig
@@ -31,11 +31,11 @@
  * @ingroup themeable
  */
 #}
-{% if logged_in -%}
+{% if logged_in and title_suffix.contextual_links -%}
   <span class="contextual-region">
     {{- title_suffix.contextual_links }}
 {% endif %}
 
 {{ content }}
 
-{% if logged_in %}</span>{% endif %}
+{% if logged_in and title_suffix.contextual_links %}</span>{% endif %}

--- a/templates/paragraph/paragraph--no-wrapper.html.twig
+++ b/templates/paragraph/paragraph--no-wrapper.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Theme override to display a paragraph.
+ */
+#}
+{%- if logged_in and title_suffix.contextual_links -%}
+  <div{{ attributes }}>
+    {{- title_suffix.contextual_links }}
+{%- endif -%}
+
+{{ content }}
+
+{%- if logged_in and title_suffix.contextual_links %}</div>{% endif -%}


### PR DESCRIPTION
This PR:

- Fixes `field--no-wrapper` so that the logic for adding the closing wrapper matches the logic for adding the opening wrapper.
- Updates `block--admin` and `media` to only add wrapper markup if logged in and there are contextual links.
- Adds `paragraph--no-wrapper` variant that can be extended, similar to `field--no-wrapper`.