### PR TITLE
includes media layout in image teaser

### DIFF
--- a/source/03-components/image-teaser/image-teaser.twig
+++ b/source/03-components/image-teaser/image-teaser.twig
@@ -5,18 +5,21 @@
   modifier_classes ? modifier_classes : '',
 ]|join(' ')|trim %}
 
-<article {{ add_attributes({ 'class': classes }) }}>
-  <div class="l-media">
-    {% if image %}
-      <div class="l-media__object">
-        <a href="{{ url }}">{{ image }}</a>
-      </div>
-    {% endif %}
+{% if image %}
+  {% set teaser_image %}
+    <a href="{{ url }}">{{ image }}</a>
+  {% endset %}
+{% endif %}
 
-    <div class="l-media__content">
-      <h2><a href="{{ url }}">{{ title }}</a></h2>
-      {{ date }}
-      {{ summary }}
-    </div>
-  </div>
+{% set teaser_content %}
+  <h2><a href="{{ url }}">{{ title }}</a></h2>
+  {{ date }}
+  {{ summary }}
+{% endset %}
+
+<article {{ add_attributes({ 'class': classes }) }}>
+  {% include '@layouts/media/media.twig' with {
+    'media': teaser_image,
+    'media_content': teaser_content,
+  } %}
 </article>


### PR DESCRIPTION
Instead of duplicating the media layout markup in the image-teaser twig file, this includes the layout.