### PR TITLE
Update default line-height tokens

### DIFF
--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -277,9 +277,12 @@ gesso:
       normal: 0
       wide: 0.02em
     line-height:
+      shortest: 1
       short: 1.1
       base: 1.45
-      tall: 1.7
+      tall: 1.6
+      taller: 1.7
+      tallest: 2
     display:
       display:
         color: text.primary


### PR DESCRIPTION
This PR updates the line-height tokens to:

- 1.0 shortest
- 1.1 short
- 1.4 base
- 1.6 tall
- 1.7 taller
- 2.0 tallest