### PR TITLE
Add paragraph_index variable for paragraph templates

### DIFF
--- a/includes/field.inc
+++ b/includes/field.inc
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function gesso_preprocess_field(&$variables) {
+  // Add index to individual paragraphs.
+  if (
+    $variables['field_type'] == 'entity_reference_revisions' &&
+    $variables['element']['#items']->getItemDefinition()->getSetting('target_type') == 'paragraph'
+  ) {
+    $delta = 0;
+    foreach ($variables['items'] as $key => $item) {
+      if (!empty($variables['items'][$key]['content']['#paragraph'])) {
+        $variables['items'][$key]['content']['#paragraph']->index = $delta;
+        $delta++;
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function gesso_theme_suggestions_field_alter(array &$suggestions, array $variables) {

--- a/includes/paragraph.inc
+++ b/includes/paragraph.inc
@@ -9,12 +9,16 @@
  * Implements theme_preprocess_paragraph().
  */
 function gesso_preprocess_paragraph(&$variables) {
-  if (isset($variables['paragraph']->parent_field_name)) {
-    $variables['parent_field'] = $variables['paragraph']->parent_field_name->value;
+  $paragraph = $variables['paragraph'];
+
+  $variables['paragraph_index'] = $paragraph->index;
+
+  if (isset($paragraph->parent_field_name)) {
+    $variables['parent_field'] = $paragraph->parent_field_name->value;
   }
 
-  if ($variables['paragraph']->getParentEntity()) {
-    $variables['parent_type'] = $variables['paragraph']->getParentEntity()->getEntityTypeId();
-    $variables['parent_bundle'] = $variables['paragraph']->getParentEntity()->bundle();
+  if ($paragraph->getParentEntity()) {
+    $variables['parent_type'] = $paragraph->getParentEntity()->getEntityTypeId();
+    $variables['parent_bundle'] = $paragraph->getParentEntity()->bundle();
   }
 }

--- a/templates/paragraph/paragraph.html.twig
+++ b/templates/paragraph/paragraph.html.twig
@@ -32,6 +32,7 @@
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
  *   is an administrator.
+ * - paragraph_index: Number of this paragraph within its parent field.
  * - parent_field: The field name that the paragraph is attached to.
  * - parent_type: The entity type that the paragraph is attached to.
  * - parent_bundle: The bundle of the entity that the paragraph is attached to.


### PR DESCRIPTION
This PR adds a `paragraph_index` variable for paragraph templates, so you can change things based on which numbered paragraph it is within its parent field.