### PR TITLE
Update hero components to be compatible with paragraph template

### DIFF
--- a/source/03-components/hero-bg-image/hero-bg-image.scss
+++ b/source/03-components/hero-bg-image/hero-bg-image.scss
@@ -11,6 +11,8 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   position: relative;
   text-align: center;
 
+  > figure,
+  > figure img,
   > img {
     height: 100%;
     left: 0;
@@ -18,6 +20,24 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
     position: absolute;
     top: 0;
     width: 100%;
+  }
+
+  &.has-content-left {
+    text-align: left;
+
+    @include breakpoint($hero-bg-image-bp) {
+      padding-left: 10%;
+      padding-right: 35%;
+    }
+  }
+
+  &.has-content-right {
+    text-align: left;
+
+    @include breakpoint($hero-bg-image-bp) {
+      padding-left: 35%;
+      padding-right: 10%;
+    }
   }
 
   &.has-overlay {
@@ -58,23 +78,5 @@ $hero-bg-image-bp: gesso-breakpoint(desktop) !default;
   @include breakpoint-max($hero-bg-image-bp, true) {
     font-size: rem(gesso-font-size(3));
     margin-bottom: rem(gesso-spacing(3));
-  }
-}
-
-.c-hero-bg-image--left {
-  text-align: left;
-
-  @include breakpoint($hero-bg-image-bp) {
-    padding-left: 10%;
-    padding-right: 35%;
-  }
-}
-
-.c-hero-bg-image--right {
-  text-align: left;
-
-  @include breakpoint($hero-bg-image-bp) {
-    padding-left: 35%;
-    padding-right: 10%;
   }
 }

--- a/source/03-components/hero-bg-image/hero-bg-image.stories.jsx
+++ b/source/03-components/hero-bg-image/hero-bg-image.stories.jsx
@@ -19,7 +19,7 @@ const Left = {
   ...Default,
   args: {
     ...data,
-    modifier_classes: 'c-hero-bg-image--left',
+    modifier_classes: 'has-content-left',
   },
 };
 
@@ -27,7 +27,7 @@ const Right = {
   ...Default,
   args: {
     ...data,
-    modifier_classes: 'c-hero-bg-image--right',
+    modifier_classes: 'has-content-right',
   },
 };
 

--- a/source/03-components/hero-bg-image/hero-bg-image.twig
+++ b/source/03-components/hero-bg-image/hero-bg-image.twig
@@ -18,9 +18,10 @@
     {% if hero_button_text and hero_button_url %}
       <div class="c-hero-bg-image__button">
         {% include '@components/button/button.twig' with {
+          'attributes': '',
           'modifier_classes': 'c-button--large',
           'url': hero_button_url,
-          'text': hero_button_text
+          'text': hero_button_text,
         } %}
       </div>
     {% endif %}

--- a/source/03-components/hero-inline-image/hero-inline-image.scss
+++ b/source/03-components/hero-inline-image/hero-inline-image.scss
@@ -56,6 +56,22 @@ $hero-inline-image-bp: gesso-breakpoint(desktop) !default;
     right: 15%;
     top: 5%;
   }
+
+  .has-content-left > & {
+    @include breakpoint($hero-inline-image-bp) {
+      align-items: flex-start;
+      left: 10%;
+      right: 35%;
+    }
+  }
+
+  .has-content-right > & {
+    @include breakpoint($hero-inline-image-bp) {
+      align-items: flex-start;
+      left: 35%;
+      right: 10%;
+    }
+  }
 }
 
 .c-hero-inline-image__title {
@@ -79,25 +95,5 @@ $hero-inline-image-bp: gesso-breakpoint(desktop) !default;
   @include breakpoint($hero-inline-image-bp) {
     color: gesso-color(text, on-dark);
     margin-bottom: rem(gesso-spacing(5));
-  }
-}
-
-.c-hero-inline-image--left {
-  .c-hero-inline-image__content {
-    @include breakpoint($hero-inline-image-bp) {
-      align-items: flex-start;
-      left: 10%;
-      right: 35%;
-    }
-  }
-}
-
-.c-hero-inline-image--right {
-  .c-hero-inline-image__content {
-    @include breakpoint($hero-inline-image-bp) {
-      align-items: flex-start;
-      left: 35%;
-      right: 10%;
-    }
   }
 }

--- a/source/03-components/hero-inline-image/hero-inline-image.stories.jsx
+++ b/source/03-components/hero-inline-image/hero-inline-image.stories.jsx
@@ -19,7 +19,7 @@ const Left = {
   ...Default,
   args: {
     ...data,
-    modifier_classes: 'c-hero-inline-image--left',
+    modifier_classes: 'has-content-left',
   },
 };
 
@@ -27,7 +27,7 @@ const Right = {
   ...Default,
   args: {
     ...data,
-    modifier_classes: 'c-hero-inline-image--right',
+    modifier_classes: 'has-content-right',
   },
 };
 

--- a/source/03-components/hero-inline-image/hero-inline-image.twig
+++ b/source/03-components/hero-inline-image/hero-inline-image.twig
@@ -8,7 +8,7 @@
 
 <div {{ add_attributes({ 'class': classes }) }}>
   <div class="c-hero-inline-image__media">
-    {{ hero_media }}
+    {{ hero_image }}
   </div>
   <div class="c-hero-inline-image__content">
     {% if hero_title %}
@@ -20,9 +20,10 @@
     {% if hero_button_text and hero_button_url %}
       <div class="c-hero-bg-image__button">
         {% include '@components/button/button.twig' with {
+          'attributes': '',
           'modifier_classes': 'c-button--large',
           'url': hero_button_url,
-          'text': hero_button_text
+          'text': hero_button_text,
         } %}
       </div>
     {% endif %}

--- a/source/03-components/hero-inline-image/hero-inline-image.yml
+++ b/source/03-components/hero-inline-image/hero-inline-image.yml
@@ -3,7 +3,7 @@ has_overlay: true
 hero_title: 'Hero Title'
 hero_summary: '<p>Hero summary text.</p>'
 hero_button_text: 'Hero Button'
-hero_media: |-
+hero_image: |-
   <picture>
     <source srcset="https://picsum.photos/1600/800?image=11" media="(min-width: 1024px)" type="image/jpeg">
     <source srcset="https://picsum.photos/1200/600?image=11" media="(min-width: 760px)" type="image/jpeg">

--- a/templates/paragraph/paragraph--hero.html.twig
+++ b/templates/paragraph/paragraph--hero.html.twig
@@ -2,12 +2,16 @@
 /**
  * @file
  * Theme implementation to display a paragraph.
+ *
+ * This paragraph can use either of the following hero components:
+ * - @components/hero-bg-image/hero-bg-image.twig
+ * - @components/hero-inline-image/hero-inline-image.twig
  */
 #}
 {% include '@components/hero-inline-image/hero-inline-image.twig' with {
   'attributes': attributes,
-  'modifier_classes': paragraph.field_hero_alignment.value ? 'c-hero-inline-image--' ~ paragraph.field_hero_alignment.value : '',
-  'hero_media': content.field_hero_image|field_value,
+  'modifier_classes': paragraph.field_hero_alignment.value ? 'has-content-' ~ paragraph.field_hero_alignment.value : '',
+  'hero_image': content.field_hero_image|field_value,
   'has_overlay': paragraph.field_hero_has_overlay is not empty ? paragraph.field_hero_has_overlay.value : false,
   'hero_title': content.field_hero_heading|field_value is not empty ? content.field_hero_heading|field_value : false,
   'hero_summary': content.field_hero_body|field_value is not empty ? content.field_hero_body|field_value : false,


### PR DESCRIPTION
This PR to #847 updates both bg and inline hero components to use the same variable names and work with the new paragraph template.