### PR TITLE
adds svg-mask-image mixin

### DIFF
--- a/source/00-config/mixins/_index.scss
+++ b/source/00-config/mixins/_index.scss
@@ -14,3 +14,4 @@
 @forward 'mod-selector';
 @forward 'responsive-font-size';
 @forward 'svg-background';
+@forward 'svg-mask-image';

--- a/source/00-config/mixins/_svg-mask-image.scss
+++ b/source/00-config/mixins/_svg-mask-image.scss
@@ -1,0 +1,8 @@
+// Mixins: SVG Mask Image
+// Can be use similarly to svg-background-image mixin, but allows color change of
+// icon using background-color property.
+
+@mixin svg-mask-image($image-name, $image-location: 'images/backgrounds/') {
+  $url: $image-location + $image-name + '.svg';
+  mask-image: url($url);
+}


### PR DESCRIPTION
Adds a svg-mask-image mixin that can be useful when you want to change the color of an icon (e.g., on hover or focus) but can't use the icon component (e.g., if you wanted an icon to appear in a commonly used class like c-button that can be added via WYSIWYG).