### PR TITLE
Attributes fixes

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,7 @@ import twigAttributes from '../lib/addAttributesTwigExtension';
 import keysort from '../lib/keysort';
 import cleanUniqueId from '../lib/cleanUniqueId';
 import fieldValue from '../lib/fieldValue';
+import twigCreateAttributes from '../lib/createAttributeTwigExtension';
 import './stubs/drupal';
 import './stubs/once';
 
@@ -18,6 +19,7 @@ function setupTwig(twig) {
   twigAttributes(twig);
   keysort(twig);
   cleanUniqueId(twig);
+  twigCreateAttributes(twig);
   fieldValue(twig);
   return twig;
 }

--- a/lib/addAttributesTwigExtension.js
+++ b/lib/addAttributesTwigExtension.js
@@ -1,37 +1,84 @@
 // @ts-check
 
 /**
+ * Follows the same general process as the PHP Twig Extension:
+ * attributes are merged if arrays, overwritten otherwise.
+ * @param {{[key: string]: any}} existingAttributes
+ * @param {{[key: string]: any}} newAttributes
+ */
+function mergeAttributes(existingAttributes, newAttributes) {
+  const mergedAttributes = { ...existingAttributes };
+  // Always treat classes as an array so they can be merged.
+  // Drupal takes care of this for us, but for Storybook, we have to do it ourselves.
+  if (
+    Object.hasOwn(mergedAttributes, 'class') &&
+    typeof mergedAttributes.class === 'string'
+  ) {
+    mergedAttributes.class = [mergedAttributes.class];
+  }
+  Object.entries(newAttributes).forEach(([key, value]) => {
+    const valueAsArray = typeof value === 'string' ? [value] : value;
+    if (
+      Object.hasOwn(mergedAttributes, key) &&
+      Array.isArray(mergedAttributes[key])
+    ) {
+      mergedAttributes[key] = mergedAttributes[key].concat(valueAsArray);
+    } else {
+      mergedAttributes[key] = valueAsArray;
+    }
+  });
+  return mergedAttributes;
+}
+
+/**
  * Generates an attributes string
  * @param {{[key: string]: any}} [additionalAttributes]
- * @param {string} [_originalAttributes]
+ * @param {string} [originalAttributes]
  * @return {string}
  */
 function handleAddAttributes(
   additionalAttributes = {},
-  _originalAttributes = ''
+  originalAttributes = 'attributes'
 ) {
-  const attributes = Object.entries(additionalAttributes).map(
-    ([key, value]) => {
-      // Exclude the _keys array and any attributes that are null, false, or
-      // undefined.
-      if (
-        key === '_keys' ||
-        value === null ||
-        typeof value === 'undefined' ||
-        value === false
-      ) {
-        return null;
+  let attributesToAdd = additionalAttributes;
+  if (typeof originalAttributes === 'object') {
+    attributesToAdd = mergeAttributes(originalAttributes, additionalAttributes);
+  } else if (
+    typeof originalAttributes === 'string' &&
+    originalAttributes.length > 0
+  ) {
+    const { context } = this;
+    let contextAttribute = { ...context };
+    originalAttributes.split('.').forEach(attribute => {
+      if (!contextAttribute[attribute]) {
+        contextAttribute = {};
+      } else {
+        contextAttribute = contextAttribute[attribute];
       }
-      // If multiples items in value as array (e.g., class: ['one', 'two']).
-      if (Array.isArray(value)) {
-        return `${key}="${value.join(' ')}"`;
-      }
-      if (typeof value === 'string' && value.includes('=')) {
-        return value;
-      }
-      return `${key}="${value}"`;
+    });
+    attributesToAdd = mergeAttributes(contextAttribute, additionalAttributes);
+  }
+
+  const attributes = Object.entries(attributesToAdd).map(([key, value]) => {
+    // Exclude the _keys array and any attributes that are null, false, or
+    // undefined.
+    if (
+      key === '_keys' ||
+      value === null ||
+      typeof value === 'undefined' ||
+      value === false
+    ) {
+      return null;
     }
-  );
+    // If multiples items in value as array (e.g., class: ['one', 'two']).
+    if (Array.isArray(value)) {
+      return `${key}="${value.join(' ')}"`;
+    }
+    if (typeof value === 'string' && value.includes('=')) {
+      return value;
+    }
+    return `${key}="${value}"`;
+  });
 
   return attributes.join(' ');
 }

--- a/lib/createAttributeTwigExtension.js
+++ b/lib/createAttributeTwigExtension.js
@@ -1,0 +1,20 @@
+/**
+ * Mocks the Drupal create_attribute() Twig function.
+ * For Storybook, just returns an object containing any attributes you put it.
+ * @see https://www.drupal.org/docs/develop/theming-drupal/twig-in-drupal/functions-in-twig-templates#s-create-attributeattributes
+ * @param startingAttributes
+ * @returns {{}}
+ */
+function createAttributes(startingAttributes = {}) {
+  return startingAttributes;
+}
+
+/**
+ * Creates the Twig extension for create_attribute.
+ * @param Twig
+ */
+function createAttributesTwigExtension(Twig) {
+  Twig.extendFunction('create_attribute', createAttributes);
+}
+
+export default createAttributesTwigExtension;

--- a/source/03-components/field/field.twig
+++ b/source/03-components/field/field.twig
@@ -30,7 +30,7 @@
   {%- endif %}
     {%- for item in field_items -%}
       {%- if display_item_tag ?? false -%}
-        <{{ field_item_tag|default('span') }} {{ item.attributes.addClass('c-field__item') }}>
+        <{{ field_item_tag|default('span') }} {{ add_attributes({ 'class': 'c-field__item' }, 'item.attributes') }}>
       {%- endif -%}
       {{- item.content -}}
       {%- if display_item_tag ?? false -%}


### PR DESCRIPTION
Brings Storybook's attribute handling closer in line with Drupal's attribute handling and closes #871 .

Stubs the `create_attribute()` [Drupal Twig function](https://www.drupal.org/docs/develop/theming-drupal/twig-in-drupal/functions-in-twig-templates#s-create-attributeattributes) so that it can be used in Storybook templates without errors. On the Storybook side, you'll get back the same object you put in. On the Drupal side, it will create an `Attribute` object from the specified attributes.

Also fixes the Storybook version of `add_attributes()` so that it will combine the attributes being added with any existing `attributes` variable (or variable of the name you give it, i.e. `item.attributes`). This already worked on the Drupal side, but Storybook was ignoring any attributes. Merging should work the same way it does with Drupal: classes are combined, but for attributes that don't take multiple values, what's added in `add_attributes()` will overwrite what was set previously.

This doesn't come up very often, but can be useful if you do have a use case where you want to set attributes in a component that's included inside another component. For example:
```twig
{% set extra_attributes = {
  class: 'some_extra_class', {# In the case of class specifically though, you could just use `modifier_class` #}
 'data-foo': 'bar'
} %}

{% include '@components/figure/figure.twig' with { attributes: create_attribute(extra_attributes) } %}
```

The outer markup on the Figure would then be:
`<figure class="some_extra_class c-figure" data-foo="bar">`