### PR TITLE
Allow modern CSS color functions to be used in design tokens

### DIFF
--- a/lib/cleanValue.cjs
+++ b/lib/cleanValue.cjs
@@ -3,6 +3,46 @@
 const { NaniError } = require('nani');
 
 /**
+ * Checks whether a value is a CSS Variable
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isCssVar(value) {
+  return value.includes('var(');
+}
+
+/**
+ * Checks whether value is a CSS color function.
+ *
+ * CSS gives us a lot of ways to write colors, all of which, for sass purposes,
+ * should be treated as numbers and not wrapped in quotes in the output.
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isColorSyntax(value) {
+  const splitValue = value.split('(');
+  if (splitValue.length <= 1) {
+    return false;
+  }
+  const functionName = splitValue[0];
+  return [
+    'rgb',
+    'rgba',
+    'hsl',
+    'hsla',
+    'lab',
+    'lch',
+    'oklab',
+    'oklch',
+    'color',
+    'color-contrast',
+    'color-mix',
+    'device-cmyk',
+    'light-dark',
+  ].includes(functionName.toLowerCase());
+}
+
+/**
  * Prepares a JS value for output as a Sass value.
  *
  * @param {number | string} value
@@ -19,10 +59,14 @@ function cleanValue(value) {
     });
   }
 
-  if (!value.includes(' ') && !value.includes('..')) {
-    return value;
+  if (
+    (value.includes(' ') || value.includes('..')) &&
+    !(isCssVar(value) || isColorSyntax(value))
+  ) {
+    return value.includes("'") ? `"${value}"` : `'${value}'`;
   }
-  return value.includes("'") ? `"${value}"` : `'${value}'`;
+
+  return value;
 }
 
 module.exports = cleanValue;


### PR DESCRIPTION
(And some less modern ones -- I kept `rgba` and `hsla` in there since browsers still support them even if they're semi-deprecated.)

Means you can do this:
```
    brand:
      blue:
        base: 'oklch(53.58% 0.144 248.04)'
        light: 'oklch(54.86% 0.099 254.73)'
        light-1: 'color(from green srgb r g b / 0.5)'
```
and still reference the tokens below, e.g. `background: brand.blue.base`. Previously, the values got wrapped in quotes in the generated Sass map, which prevented them from displaying correctly.