### PR TITLE
Component script fixes

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -99,7 +99,7 @@ function makeComponentFile(
       output = `{% set classes = [
   '${componentCSSClass}',
   modifier_classes ? modifier_classes : ''
-] %}
+]|join(' ')|trim %}
 
 <div {{ add_attributes({ class: classes }) }}>
 </div>
@@ -120,13 +120,15 @@ const settings = {
   title: 'Components/${componentTitle}'
 };
 
-const ${componentJSClass} = args =>
-  parse(
-    twigTemplate({
-      ...args,
-    })
-  );
-${componentJSClass}.args = { ...data };
+const ${componentJSClass} = {
+  render: args =>
+    parse(
+      twigTemplate({
+        ...args,
+      })
+    ),
+  args: { ...data },
+};  
 
 export default settings;
 export { ${componentJSClass} };

--- a/lib/component.js
+++ b/lib/component.js
@@ -227,7 +227,7 @@ async function getComponentDetails(componentName, patternDir) {
       type: 'confirm',
       name: 'library',
       message: 'Create a separate modular CSS file?',
-      default: false,
+      default: true,
     },
   ];
   return inquirer.prompt(detailedQuestions);


### PR DESCRIPTION
Updates `npm run component` so that it creates the `.stories.jsx` file using the more recent Storybook CSF format, joins and trims the `classes` variable, and defaults to creating a separate CSS file (for use in a library) unless you choose `N`. (Still supports both, as it did before -- change impacts which option you have to type a letter for and which you can just hit Enter on.)