### PR TITLE
Add subheading_level Twig filter

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,7 @@ import twigAttributes from '../lib/addAttributesTwigExtension';
 import keysort from '../lib/keysort';
 import cleanUniqueId from '../lib/cleanUniqueId';
 import fieldValue from '../lib/fieldValue';
+import subheadingLevel from '../lib/subheadingLevelTwigExtension.js';
 import './stubs/drupal';
 import './stubs/once';
 
@@ -19,6 +20,7 @@ function setupTwig(twig) {
   keysort(twig);
   cleanUniqueId(twig);
   fieldValue(twig);
+  subheadingLevel(twig);
   return twig;
 }
 

--- a/README.md
+++ b/README.md
@@ -591,6 +591,43 @@ set to `true` (default: `false`).
 }
 ```
 
+## Twig Filters and Functions
+Gesso includes some additional filters and functions that can be used in Twig templates.
+
+#### add_attributes
+Fork of [Drupal Pattern Lab's `add_attribute` Twig function](https://github.com/drupal-pattern-lab/add-attributes-twig-extension).
+Allows Twig templates to add attributes that, in Drupal, will be merged with the Drupal attributes object
+while also rendering in Storybook.
+
+```twig
+<div {{ add_attributes(
+  {
+    class: 'your-class-one your-class-two',
+    'data-foo': 'bar'
+  }
+) }}>...</div>    
+```
+
+#### keysort
+Twig filter to sort an object by key alphabetically.
+
+```twig
+{% for key, value in your_object|keysort %}
+...
+{% endfor %}
+```
+
+### subheading_level
+Twig filter to transform a heading tag to the next level down (h2 -> h3, h3 -> h4, etc.)
+Used when the parent heading level can vary but, to maintain accessibility, the component's
+heading or subheading should change accordingly.
+
+```twig
+{% set subheading_element = title_element|subheading_level %}
+
+<{{ subheading_element|default('h3') }}>...</{{ subheading_element|default('h3') }}>
+```
+
 ## Building Storybook
 
 A static Storybook site can be built with `npm run build-storybook`. You will

--- a/gesso_helper/src/TwigExtension/SubheadingLevelTwigExtension.php
+++ b/gesso_helper/src/TwigExtension/SubheadingLevelTwigExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\gesso_helper\TwigExtension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+/**
+ * Gesso theme twig extension for converting a heading level to the next
+ * level down.
+ */
+class SubheadingLevelTwigExtension extends AbstractExtension {
+  /**
+   * Provide helper name.
+   */
+  public function getName() {
+    return 'gesso_helper_subheading_level';
+  }
+
+  /**
+   * Add subheading_level Twig filter.
+   */
+  public function getFilters() {
+    $filters = parent::getFilters();
+    $filters[] = new TwigFilter('subheading_level', [$this, 'subheadingLevel']);
+    return $filters;
+  }
+
+  public function subheadingLevel($level) {
+    $level = strtolower($level);
+    $matches = [];
+    if (preg_match('/^h(\\d)$/', $level, $matches)) {
+      // Don't go any lower than h6
+      $newLevel = min($matches[1] + 1, 6);
+      return "h$newLevel";
+    }
+
+    // If we got something other than a heading level, return the tag
+    // converted to lower-case but otherwise unchanged.
+    return $level;
+  }
+}

--- a/lib/subheadingLevelTwigExtension.js
+++ b/lib/subheadingLevelTwigExtension.js
@@ -1,0 +1,13 @@
+function subheadingLevelTwigExtension(twigInstance) {
+  twigInstance.extendFilter('subheading_level', value => {
+    const lowerValue = value.toLowerCase();
+    const matches = lowerValue.match(/^h(\d)$/);
+    if (matches !== null && matches.length >= 2) {
+      const newLevel = Math.min(Number(matches[1]) + 1, 6);
+      return `h${newLevel}`;
+    }
+    return lowerValue;
+  });
+}
+
+export default subheadingLevelTwigExtension;


### PR DESCRIPTION
Twig filter to transform a heading tag to the next level down (h2 -> h3, h3 -> h4, etc.) Used when the parent heading level can vary (e.g. it's controlled by the site editor as part of a paragraph) but, to maintain accessibility, the component's heading or subheading (e.g. in a nested paragraph) should change accordingly.