### PR TITLE
adds styles for extlink icon

### DIFF
--- a/source/03-components/00-module-overrides/extlink/_extlink.scss
+++ b/source/03-components/00-module-overrides/extlink/_extlink.scss
@@ -1,0 +1,14 @@
+// external link icon styling
+svg.ext {
+  fill: currentColor;
+  height: 0.9em;
+  margin-block-end: 0.2em;
+  margin-inline-end: -0.15em;
+  margin-inline-start: 0.1em;
+  padding-inline-end: 0;
+  width: 0.9em;
+
+  path {
+    stroke: currentColor;
+  }
+}

--- a/source/03-components/_index.scss
+++ b/source/03-components/_index.scss
@@ -1,6 +1,7 @@
 $wysiwyg: false !default;
 
 @use '00-cms-styles/toolbar-menu/toolbar-menu';
+@use '00-module-overrides/extlink/extlink';
 @use 'article/article';
 @use 'author/author';
 @use 'button/button';


### PR DESCRIPTION
This augments the default styling of the external link icon from the extlink module, making it match the color/size of its parent and generally look better next to lines of text.