### PR TITLE
adjusted content area of default page template

### DIFF
--- a/source/03-components/article/article.twig
+++ b/source/03-components/article/article.twig
@@ -45,9 +45,11 @@
     </footer>
   {% endif %}
 
-  {% block content %}
-    {% include '@components/wysiwyg/wysiwyg.twig' with {
-      'content': content,
-    } %}
-  {% endblock %}
+  <div class="c-article__content">
+    {% block content %}
+      {% include '@components/wysiwyg/wysiwyg.twig' with {
+        'content': content,
+      } %}
+    {% endblock %}
+  </div>
 </article>

--- a/source/04-templates/page/page.twig
+++ b/source/04-templates/page/page.twig
@@ -4,10 +4,14 @@
   'admin_info': admin_info,
 } %}
 
-{% include '@components/article/article.twig' with {
+{% embed '@components/article/article.twig' with {
   'attributes': attributes,
   'title': title,
   'show_footer': show_footer,
   'author_name': author_name,
   'content': content,
 } %}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
* Added a wrapper div around article content.
* While I think it makes sense for the default article content to be wrapped in the wysiwyg, our default page template uses article and generally a page will have its own wysiwyg or other paragraph components.  Due to that, I've used the content block to just pass content in directly without the wysiwyg wrapper.