### PR TITLE
[GESSO-901] Fixes #901

### DIFF
--- a/gesso_helper/src/Element/GessoButton.php
+++ b/gesso_helper/src/Element/GessoButton.php
@@ -4,7 +4,7 @@ namespace Drupal\gesso_helper\Element;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\Core\Render\Element\RenderElement;
+use Drupal\Core\Render\Element\RenderElementBase;
 use Drupal\Core\Url as CoreUrl;
 
 /**
@@ -35,7 +35,7 @@ use Drupal\Core\Url as CoreUrl;
  *
  * @RenderElement("gesso_button")
  */
-class GessoButton extends RenderElement {
+class GessoButton extends RenderElementBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Changes parent class of GessoButton from RenderElement to RenderElementBase.

While this is the apparent change to fix the issue I described in #901 , I'm having trouble being certain testing this is working. If I drop an xdebug breakpoint in `GessoButton::preRenderLink()` I see it will hit that point, and I see elements on the front-end with the `c-button` class, but I'm not certain if that's generic enough it's being used elsewhere. In any case, it seems likely that this provides the needed fix. But I'll let someone review it. 