### PR TITLE
Disabling block title visibility for the Gesso Tools block.

### DIFF
--- a/config/install/block.block.gesso_tools.yml
+++ b/config/install/block.block.gesso_tools.yml
@@ -17,7 +17,7 @@ settings:
   id: 'system_menu_block:tools'
   label: Tools
   provider: system
-  label_display: visible
+  label_display: '0'
   level: 1
   depth: 0
   expand_all_items: false


### PR DESCRIPTION
This block's title is enabled by default which we often want to have disabled by default.