### PR TITLE
fixes empty header tag being created if view has no title

### DIFF
--- a/includes/views.inc
+++ b/includes/views.inc
@@ -14,7 +14,7 @@ function gesso_preprocess_views_view(array &$variables) {
 
   $variables['path'] = $view->getRequest()->getPathInfo();
 
-  if (empty($variables['title'])) {
+  if (empty($variables['title']) && !empty($view->getTitle())) {
     $variables['title'] = [
       '#markup' => $view->getTitle(),
     ];


### PR DESCRIPTION
Currently if a view title is left empty, the H2 tag is still created for it (with no text).  This fixes that.