### PR TITLE
fixes for typing error

### DIFF
--- a/source/03-components/external-link/external-link.es6.ts
+++ b/source/03-components/external-link/external-link.es6.ts
@@ -7,7 +7,7 @@ Drupal.behaviors.externalLink = {
     const exitDisclaimer = settings?.gesso?.externalLinkExitDisclaimer ?? Drupal.t('Exit this website');
     const allowedDomains = settings?.gesso?.externalLinkAllowedDomains ?? [];
     const allowedLinks = settings?.gesso?.externalLinkAllowedLinks ?? [];
-    const externalLinks: NodeListOf<HTMLAnchorElement> = once(
+    const externalLinks: Element[] = once(
       'external-link',
       "a:not([data-not-external-link], [href=''], [href^='#'], [href^='?'], [href^='/'], [href^='.'], [href^='javascript:'], [href^='mailto:'], [href^='tel:'])",
       context
@@ -39,7 +39,10 @@ Drupal.behaviors.externalLink = {
     }
 
     externalLinks.forEach(link => {
-      if (link.hasAttribute('href') && linkIsExternal(link)) {
+      if (
+        link.hasAttribute('href') &&
+        linkIsExternal(link as HTMLAnchorElement)
+      ) {
         const accessibleLabel = exitDisclaimer;
 
         link.insertAdjacentHTML(


### PR DESCRIPTION
I saw some typing errors when compiling this locally.

```
Property 'item' is missing in type 'Element[]' but required in type 'NodeListOf<HTMLAnchorElement>'.
```

Copilot suggested the changes I've made in this PR.

That seemed to fix the errors and the functionality seems to work in my testing. If that PR looks ok to you, I can go ahead and move forward with this and merge both PRs.