### PR TITLE
Accordion prevent default event fix

### DIFF
--- a/source/03-components/accordion/accordion.es6.js
+++ b/source/03-components/accordion/accordion.es6.js
@@ -74,8 +74,8 @@ Drupal.behaviors.accordion = {
           } else if (allowToggle && isExpanded) {
             closeAccordion(target);
           }
+          event.preventDefault(); // Only prevent default for accordion toggle clicks
         }
-        event.preventDefault();
       });
 
       // Bind keyboard behaviors on the main accordion container


### PR DESCRIPTION
Updated the accordion JS to only prevent default events on toggle clicks. (This was preventing link clicks inside accordion drawers.)