### PR TITLE
added global library as a dependency to other libraries

### DIFF
--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -29,6 +29,7 @@ accordion_step_list:
     theme:
       dist/css/accordion--step-list.css: {}
   dependencies:
+    - gesso/global
     - gesso/accordion
 
 back_to_top:
@@ -95,6 +96,7 @@ dropdown_menu:
     dist/js/dropdown-menu.es6.js: {}
   dependencies:
     - core/once
+    - gesso/global
     - gesso/mobile_menu
 
 external-link:
@@ -117,6 +119,7 @@ file:
     theme:
       dist/css/file.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 filters:
@@ -169,6 +172,7 @@ mega_menu:
     dist/js/mega-menu.es6.js: {}
   dependencies:
     - core/once
+    - gesso/global
     - gesso/mobile_menu
 
 message:
@@ -183,6 +187,7 @@ mobile_menu:
     theme:
       dist/css/mobile-menu.css: {}
   dependencies:
+    - gesso/global
     - gesso/hamburger_button
 
 modal:
@@ -202,6 +207,7 @@ overlay_menu:
   js:
     dist/js/overlay-menu.es6.js: {}
   dependencies:
+    - gesso/global
     - core/once
     - gesso/hamburger_button
 
@@ -217,6 +223,7 @@ pager_mini:
     theme:
       dist/css/pager--mini.css: {}
   dependencies:
+    - gesso/global
     - gesso/pager
 
 progress:
@@ -242,6 +249,7 @@ read_more_link:
     theme:
       dist/css/rss-more-link.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 rss_feed:
@@ -249,6 +257,7 @@ rss_feed:
     theme:
       dist/css/rss-feed.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 side_menu:
@@ -259,6 +268,7 @@ side_menu:
     dist/js/side-menu.es6.js: {}
   dependencies:
     - core/once
+    - gesso/global
     - gesso/hamburger_button
 
 tag:
@@ -273,6 +283,7 @@ tag_list:
     theme:
       dist/css/tag-list.css: {}
   dependencies:
+    - gesso/global
     - gesso/tag
 
 teaser:

--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -20,9 +20,7 @@ accordion:
   js:
     dist/js/accordion.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
     - gesso/global
 
 accordion_step_list:
@@ -31,9 +29,6 @@ accordion_step_list:
     theme:
       dist/css/accordion--step-list.css: {}
   dependencies:
-    - core/drupal
-    - core/once
-    - gesso/global
     - gesso/accordion
 
 back_to_top:
@@ -43,9 +38,7 @@ back_to_top:
   js:
     dist/js/back-to-top.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
     - gesso/global
 
 block:
@@ -90,10 +83,8 @@ dropbutton:
     component:
       dist/css/dropbutton.css: {}
   dependencies:
-    - core/drupal
     - core/drupalSettings
     - core/once
-    - gesso/common
     - gesso/global
 
 dropdown_menu:
@@ -103,19 +94,14 @@ dropdown_menu:
   js:
     dist/js/dropdown-menu.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
-    - gesso/global
     - gesso/mobile_menu
 
 external-link:
   js:
     dist/js/external-link.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
     - gesso/global
 
 facets:
@@ -131,7 +117,6 @@ file:
     theme:
       dist/css/file.css: {}
   dependencies:
-    - gesso/global
     - gesso/icon_link
 
 filters:
@@ -183,10 +168,7 @@ mega_menu:
   js:
     dist/js/mega-menu.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
-    - gesso/global
     - gesso/mobile_menu
 
 message:
@@ -201,7 +183,6 @@ mobile_menu:
     theme:
       dist/css/mobile-menu.css: {}
   dependencies:
-    - gesso/global
     - gesso/hamburger_button
 
 modal:
@@ -211,9 +192,7 @@ modal:
   js:
     dist/js/modal.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
     - gesso/global
 
 overlay_menu:
@@ -223,10 +202,7 @@ overlay_menu:
   js:
     dist/js/overlay-menu.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
-    - gesso/global
     - gesso/hamburger_button
 
 pager:
@@ -241,7 +217,6 @@ pager_mini:
     theme:
       dist/css/pager--mini.css: {}
   dependencies:
-    - gesso/global
     - gesso/pager
 
 progress:
@@ -267,7 +242,6 @@ read_more_link:
     theme:
       dist/css/rss-more-link.css: {}
   dependencies:
-    - gesso/global
     - gesso/icon_link
 
 rss_feed:
@@ -275,7 +249,6 @@ rss_feed:
     theme:
       dist/css/rss-feed.css: {}
   dependencies:
-    - gesso/global
     - gesso/icon_link
 
 side_menu:
@@ -285,10 +258,7 @@ side_menu:
   js:
     dist/js/side-menu.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
-    - gesso/global
     - gesso/hamburger_button
 
 tag:
@@ -303,7 +273,6 @@ tag_list:
     theme:
       dist/css/tag-list.css: {}
   dependencies:
-    - gesso/global
     - gesso/tag
 
 teaser:
@@ -324,7 +293,5 @@ wysiwyg:
   js:
     dist/js/wysiwyg.es6.js: {}
   dependencies:
-    - core/drupal
     - core/once
-    - gesso/common
     - gesso/global

--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -10,6 +10,7 @@ global:
     dist/js/table--sortable.es6.js: {}
   dependencies:
     - core/drupal
+    - core/once
     - gesso/common
 
 accordion:
@@ -20,7 +21,6 @@ accordion:
   js:
     dist/js/accordion.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
 
 accordion_step_list:
@@ -39,7 +39,6 @@ back_to_top:
   js:
     dist/js/back-to-top.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
 
 block:
@@ -85,7 +84,6 @@ dropbutton:
       dist/css/dropbutton.css: {}
   dependencies:
     - core/drupalSettings
-    - core/once
     - gesso/global
 
 dropdown_menu:
@@ -95,7 +93,6 @@ dropdown_menu:
   js:
     dist/js/dropdown-menu.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
     - gesso/mobile_menu
 
@@ -103,7 +100,6 @@ external-link:
   js:
     dist/js/external-link.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
 
 facets:
@@ -171,7 +167,6 @@ mega_menu:
   js:
     dist/js/mega-menu.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
     - gesso/mobile_menu
 
@@ -197,7 +192,6 @@ modal:
   js:
     dist/js/modal.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
 
 overlay_menu:
@@ -208,7 +202,6 @@ overlay_menu:
     dist/js/overlay-menu.es6.js: {}
   dependencies:
     - gesso/global
-    - core/once
     - gesso/hamburger_button
 
 pager:
@@ -267,7 +260,6 @@ side_menu:
   js:
     dist/js/side-menu.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global
     - gesso/hamburger_button
 
@@ -304,5 +296,4 @@ wysiwyg:
   js:
     dist/js/wysiwyg.es6.js: {}
   dependencies:
-    - core/once
     - gesso/global

--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -23,6 +23,7 @@ accordion:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
 
 accordion_step_list:
   header: true
@@ -32,7 +33,7 @@ accordion_step_list:
   dependencies:
     - core/drupal
     - core/once
-    - gesso/common
+    - gesso/global
     - gesso/accordion
 
 back_to_top:
@@ -45,31 +46,42 @@ back_to_top:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
 
 block:
   css:
     theme:
       dist/css/block.css: {}
+  dependencies:
+    - gesso/global
 
 breadcrumb:
   css:
     theme:
       dist/css/breadcrumb.css: {}
+  dependencies:
+    - gesso/global
 
 call_to_action:
   css:
     theme:
       dist/css/call-to-action.css: {}
+  dependencies:
+    - gesso/global
 
 card:
   css:
     theme:
       dist/css/card.css: {}
+  dependencies:
+    - gesso/global
 
 details:
   css:
     theme:
       dist/css/details.css: {}
+  dependencies:
+    - gesso/global
 
 dropbutton:
   js:
@@ -82,6 +94,7 @@ dropbutton:
     - core/drupalSettings
     - core/once
     - gesso/common
+    - gesso/global
 
 dropdown_menu:
   css:
@@ -93,6 +106,7 @@ dropdown_menu:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
     - gesso/mobile_menu
 
 external-link:
@@ -102,6 +116,7 @@ external-link:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
 
 facets:
   css:
@@ -109,13 +124,14 @@ facets:
       dist/css/facet.css: {}
       dist/css/facet-list.css: {}
   dependencies:
-    - gesso/common
+    - gesso/global
 
 file:
   css:
     theme:
       dist/css/file.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 filters:
@@ -123,32 +139,42 @@ filters:
     theme:
       dist/css/filters.css: {}
   dependencies:
-    - gesso/common
+    - gesso/global
 
 hamburger_button:
   css:
     theme:
       dist/css/hamburger-button.css: {}
+  dependencies:
+    - gesso/global
 
 hero_bg_image:
   css:
     theme:
       dist/css/hero-bg-image.css: {}
+  dependencies:
+    - gesso/global
 
 hero_inline_image:
   css:
     theme:
       dist/css/hero-inline-image.css: {}
+  dependencies:
+    - gesso/global
 
 icon_link:
   css:
     theme:
       dist/css/icon-link.css: {}
+  dependencies:
+    - gesso/global
 
 image_teaser:
   css:
     theme:
       dist/css/image-teaser.css: {}
+  dependencies:
+    - gesso/global
 
 mega_menu:
   css:
@@ -160,18 +186,22 @@ mega_menu:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
     - gesso/mobile_menu
 
 message:
   css:
     theme:
       dist/css/message.css: {}
+  dependencies:
+    - gesso/global
 
 mobile_menu:
   css:
     theme:
       dist/css/mobile-menu.css: {}
   dependencies:
+    - gesso/global
     - gesso/hamburger_button
 
 modal:
@@ -184,6 +214,7 @@ modal:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
 
 overlay_menu:
   css:
@@ -195,24 +226,30 @@ overlay_menu:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
     - gesso/hamburger_button
 
 pager:
   css:
     theme:
       dist/css/pager.css: {}
+  dependencies:
+    - gesso/global
 
 pager_mini:
   css:
     theme:
       dist/css/pager--mini.css: {}
   dependencies:
+    - gesso/global
     - gesso/pager
 
 progress:
   css:
     theme:
       dist/css/progress.css: {}
+  dependencies:
+    - gesso/global
 
 react:
   js:
@@ -230,6 +267,7 @@ read_more_link:
     theme:
       dist/css/rss-more-link.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 rss_feed:
@@ -237,6 +275,7 @@ rss_feed:
     theme:
       dist/css/rss-feed.css: {}
   dependencies:
+    - gesso/global
     - gesso/icon_link
 
 side_menu:
@@ -249,29 +288,37 @@ side_menu:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global
     - gesso/hamburger_button
 
 tag:
   css:
     theme:
       dist/css/tag.css: {}
+  dependencies:
+    - gesso/global
 
 tag_list:
   css:
     theme:
       dist/css/tag-list.css: {}
   dependencies:
+    - gesso/global
     - gesso/tag
 
 teaser:
   css:
     theme:
       dist/css/teaser.css: {}
+  dependencies:
+    - gesso/global
 
 video:
   css:
     theme:
       dist/css/video.css: {}
+  dependencies:
+    - gesso/global
 
 wysiwyg:
   js:
@@ -280,3 +327,4 @@ wysiwyg:
     - core/drupal
     - core/once
     - gesso/common
+    - gesso/global


### PR DESCRIPTION
Something has changed in recent versions of Drupal which has affected the CSS load order of libraries. In prior versions all of our library CSS was loaded after styles.css, but now many of them are loading before.  To fix this I've added the global library as a dependency on all libraries that have custom CSS.  