### PR TITLE
fixed overloooked class name in navigation.inc

### DIFF
--- a/includes/navigation.inc
+++ b/includes/navigation.inc
@@ -73,7 +73,7 @@ function gesso_preprocess_menu_local_tasks(array &$variables): void {
  * Implements hook_preprocess_menu_local_task().
  */
 function gesso_preprocess_menu_local_task(array &$variables): void {
-  $variables['link']['#options']['attributes']['class'][] = 'c-button-group__link';
+  $variables['link']['#options']['attributes']['class'][] = 'c-button-group-item__link';
   $variables['link']['#options']['attributes']['class'][] = 'c-button';
   $variables['link']['#options']['attributes']['class'][] = 'c-button--base';
 


### PR DESCRIPTION
Caught as part of a project upgrade.  I think this class needs to be updated to `c-button-group-item__link`. 