### PR TITLE
Added in missed :void in field function

### DIFF
--- a/includes/field.inc
+++ b/includes/field.inc
@@ -8,7 +8,7 @@
 /**
  * Implements hook_preprocess_HOOK().
  */
-function gesso_preprocess_field(array &$variables) {
+function gesso_preprocess_field(array &$variables): void {
   // Add index to individual paragraphs.
   if (
     $variables['field_type'] == 'entity_reference_revisions' &&


### PR DESCRIPTION
Caught as part of a project theme upgrade.  Looks like this function could use the `:void` as well to be consistent.