### PR TITLE
makes author url explicit in article component

### DIFF
--- a/source/00-config/storybook.global-data.yml
+++ b/source/00-config/storybook.global-data.yml
@@ -12,6 +12,7 @@ is_published: true
 show_admin_info: false
 summary: '<p>This is the summary, which can contain <abbr title="Hyper Text Markup Language">HTML</abbr> markup. It should be 600 characters or less.</p>'
 author_name: 'Author Name'
+author_url: '#0'
 url: '#0'
 file_name: 'File name'
 file_mime: 'application/pdf'

--- a/source/03-components/article/article.twig
+++ b/source/03-components/article/article.twig
@@ -23,7 +23,7 @@
           {% endset %}
         {% endif %}
 
-        {% if not author %}
+        {% if not author and author_name and author_url %}
           {% set author %}
             {% include '@components/author/author.twig' with {
                 'author': author_name,

--- a/source/03-components/article/article.twig
+++ b/source/03-components/article/article.twig
@@ -27,6 +27,7 @@
           {% set author %}
             {% include '@components/author/author.twig' with {
                 'author': author_name,
+                'url': author_url,
               } %}
           {% endset %}
         {% endif %}

--- a/source/03-components/article/article.yml
+++ b/source/03-components/article/article.yml
@@ -1,4 +1,3 @@
 ---
 title: 'Article Title'
-author_url: '#0'
 show_footer: true

--- a/source/03-components/article/article.yml
+++ b/source/03-components/article/article.yml
@@ -1,3 +1,4 @@
 ---
 title: 'Article Title'
+author_url: '#0'
 show_footer: true

--- a/source/04-templates/page/page.twig
+++ b/source/04-templates/page/page.twig
@@ -8,7 +8,7 @@
   'attributes': attributes,
   'title': title,
   'show_footer': show_footer,
-  'author_name': author_name,
+  'author': author,
 } %}
   {% block content %}
     {{ content }}

--- a/source/05-pages/article.stories.jsx
+++ b/source/05-pages/article.stories.jsx
@@ -69,6 +69,7 @@ const articleContent = args =>
         short: '9',
       },
       author_name: 'William Goldman',
+      author_url: '#0',
       content: articleDemoContent,
     })
   );


### PR DESCRIPTION
Updated how author name/url is treated in the article.twig file to be more consistent.