### PR TITLE
switch body from overflow hidden to clip

### DIFF
--- a/source/01-global/html-elements/02-body/_body.scss
+++ b/source/01-global/html-elements/02-body/_body.scss
@@ -16,7 +16,7 @@ body {
   background-color: gesso-color(background, site);
   color: gesso-color(text, primary);
   margin: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
   padding: 0;
   width: 100%;
   word-wrap: break-word;


### PR DESCRIPTION
I've run into issues with overflow: hidden on the body tag interfering with position sticky.  On a recent project I switched to overflow: clip, which solved the horizontal scroll bar issue on full bleed objects but didn't break sticky.  Adding that same change here.