### PR TITLE
stop aggregating theme js

### DIFF
--- a/gesso.libraries.yml
+++ b/gesso.libraries.yml
@@ -227,12 +227,7 @@ progress:
 
 react:
   js:
-    # Setting preprocess to false is important since we're using
-    # code-spliting (lazy()) in our React code. If Drupal's
-    # JS aggregation is turned on, only the main.js file will
-    # get aggregated. The split code won't and Drupal will
-    # erroneously try to load it from /sites/default/files/js.
-    dist/js/react/main.js: { preprocess: false }
+    dist/js/react/main.js: {}
   dependencies:
     - core/drupalSettings
 

--- a/includes/libraries.inc
+++ b/includes/libraries.inc
@@ -22,6 +22,28 @@ function gesso_library_info_build(): array {
 }
 
 /**
+ * Implements hook_library_info_alter().
+ */
+function gesso_library_info_alter(array &$libraries, string $extension): void {
+  if ($extension !== 'gesso') {
+    return;
+  }
+
+  // Stop Webpack/Terser output from passing through Drupal JS aggregation.
+  foreach ($libraries as &$library) {
+    if (empty($library['js'])) {
+      continue;
+    }
+    foreach ($library['js'] as $path => &$options) {
+      if (!is_string($path) || !str_starts_with($path, 'dist/js/')) {
+        continue;
+      }
+      $options['preprocess'] = FALSE;
+    }
+  }
+}
+
+/**
  * Implements hook_element_info_alter().
  */
 function gesso_element_info_alter(array &$types): void {


### PR DESCRIPTION
I keep hitting issues on projects where Drupal's aggregation of JS causes things to break (but everything works fine without aggregation).  Cursor suggested adding preprocess: false to the affected file... but also pointed out that Webpack is already minimizing the files and aggregation is redundant to prone to causing issues. Given that, I've started disabling aggregation for all our processed JS files.  This PR does the same.  Do you think we should adopt this approach?