### PR TITLE
updated twig cache busting

### DIFF
--- a/templates/content/node--full.html.twig
+++ b/templates/content/node--full.html.twig
@@ -97,4 +97,4 @@
 } %}
 
 {# Uncomment the following if you don’t render the content variable. #}
-{# {% set catch_cache = content|render %} #}
+{# {{ content|cache_metadata }} #}

--- a/templates/content/node--teaser.html.twig
+++ b/templates/content/node--teaser.html.twig
@@ -23,4 +23,4 @@
 } %}
 
 {# Uncomment the following if you don’t render the content variable. #}
-{# {% set catch_cache = content|render %} #}
+{# {{ content|cache_metadata }} #}

--- a/templates/content/taxonomy-term--full.html.twig
+++ b/templates/content/taxonomy-term--full.html.twig
@@ -44,4 +44,4 @@
 } %}
 
 {# Uncomment the following if you don’t render the content variable. #}
-{# {% set catch_cache = content|render %} #}
+{# {{ content|cache_metadata }} #}

--- a/templates/layout/layout--onecol.html.twig
+++ b/templates/layout/layout--onecol.html.twig
@@ -24,4 +24,4 @@
   {% endif %}
 {% endif %}
 
-{% set catch_cache = content|render %}
+{{ content|cache_metadata }}

--- a/templates/layout/layout--sidebar.html.twig
+++ b/templates/layout/layout--sidebar.html.twig
@@ -14,4 +14,4 @@
   } %}
 {% endif %}
 
-{% set catch_cache = content|render %}
+{{ content|cache_metadata }}

--- a/templates/media/media--full.html.twig
+++ b/templates/media/media--full.html.twig
@@ -30,4 +30,4 @@
 } %}
 
 {# Uncomment the following if you don’t render the content variable. #}
-{# {% set catch_cache = content|render %} #}
+{# {{ content|cache_metadata }} #}

--- a/templates/media/media.html.twig
+++ b/templates/media/media.html.twig
@@ -37,3 +37,6 @@
 {{ content }}
 
 {% if logged_in and title_suffix.contextual_links %}</span>{% endif %}
+
+{# Uncomment the following if you don’t render the content variable. #}
+{# {{ content|cache_metadata }} #}

--- a/templates/paragraph/paragraph--accordion-item.html.twig
+++ b/templates/paragraph/paragraph--accordion-item.html.twig
@@ -12,4 +12,4 @@
   'content': content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
 } %}
 
-{% set catch_cache = content|without('field_title', 'field_wysiwyg')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--accordion.html.twig
+++ b/templates/paragraph/paragraph--accordion.html.twig
@@ -13,4 +13,4 @@
   'accordion_items': content.field_paragraphs|field_value is not empty ? content.field_paragraphs|field_value : false,
 } %}
 
-{% set catch_cache = content|without('field_paragraphs')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--call-to-action.html.twig
+++ b/templates/paragraph/paragraph--call-to-action.html.twig
@@ -14,8 +14,4 @@
   'link_title': content.field_cta_link|field_value is not empty ? content.field_cta_link.0['#title'] : false,
 } %}
 
-{#
-  field_cta_link is intentionally omitted from the |without list because specific values are
-  extracted from it, bypassing the normal render process.
-#}
-{% set catch_cache = content|without('field_cta_media', 'field_cta_heading', 'field_cta_body') %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--card.html.twig
+++ b/templates/paragraph/paragraph--card.html.twig
@@ -12,4 +12,4 @@
   'card_content': content.field_card_subtitle|field_value is not empty ? content.field_card_subtitle|field_value : false,
 } %}
 
-{% set catch_cache = content|without('field_card_media', 'field_card_title', 'field_card_link', 'field_card_subtitle')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--cards.html.twig
+++ b/templates/paragraph/paragraph--cards.html.twig
@@ -19,4 +19,4 @@
   'section_content': section_content,
 } %}
 
-{% set catch_cache = content|without('field_cards')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--hero.html.twig
+++ b/templates/paragraph/paragraph--hero.html.twig
@@ -20,9 +20,5 @@
   'hero_button_url': content.field_hero_link|field_value is not empty ? content.field_hero_link.0['#url'] : false,
 } %}
 
-{#
-  field_hero_link and field_hero_aligment are intentionally omitted from the
-  |without list because specific values are extracted from them, bypassing the
-  normal render process.
-#}
-{% set catch_cache = content|without('field_hero_image', 'field_hero_heading', 'field_hero_body') %}
+{{ paragraph|cache_metadata }}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--hero.html.twig
+++ b/templates/paragraph/paragraph--hero.html.twig
@@ -20,5 +20,4 @@
   'hero_button_url': content.field_hero_link|field_value is not empty ? content.field_hero_link.0['#url'] : false,
 } %}
 
-{{ paragraph|cache_metadata }}
 {{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--tab.html.twig
+++ b/templates/paragraph/paragraph--tab.html.twig
@@ -6,4 +6,4 @@
 #}
 {{ content.field_wysiwyg|field_value }}
 
-{% set catch_cache = content|without('field_wysiwyg')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--tabs.html.twig
+++ b/templates/paragraph/paragraph--tabs.html.twig
@@ -16,4 +16,4 @@
   'tab_panels': content.field_paragraphs|field_value is not empty ? content.field_paragraphs|field_value : false,
 } %}
 
-{% set catch_cache = content|without('field_paragraphs')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph--wysiwyg.html.twig
+++ b/templates/paragraph/paragraph--wysiwyg.html.twig
@@ -10,4 +10,4 @@
   'content': content.field_wysiwyg|field_value is not empty ? content.field_wysiwyg|field_value : false,
 }%}
 
-{% set cache_catch = content|without('field_wysiwyg')|render %}
+{{ content|cache_metadata }}

--- a/templates/paragraph/paragraph.html.twig
+++ b/templates/paragraph/paragraph.html.twig
@@ -52,3 +52,6 @@
     {{ content }}
   </div>
 {% endblock %}
+
+{# Uncomment the following if you don’t render the content variable. #}
+{# {{ content|cache_metadata }} #}

--- a/templates/user/user--full.html.twig
+++ b/templates/user/user--full.html.twig
@@ -37,4 +37,4 @@
 } %}
 
 {# Uncomment the following if you don’t render the content variable. #}
-{# {% set catch_cache = content|render %} #}
+{# {{ content|cache_metadata }} #}


### PR DESCRIPTION
Switching to use Twig Tweak's cache_metadata vs explicitly re-rendering the entire content variable.