### PR TITLE
linting updates

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,8 +3,10 @@ import f1BaseConfig from '@forumone/eslint-config-es5';
 import f1StorybookConfig from '@forumone/eslint-config-es5/storybook';
 import f1ReactConfig from '@forumone/eslint-config-react';
 
+const reactFiles = ['**/*.tsx', '**/*.jsx'];
+
 const config = defineConfig([
-  globalIgnores(['**/_GESSO.es6.js']),
+  globalIgnores(['**/_GESSO.es6.js', 'source/@types/**']),
   {
     settings: {
       react: {
@@ -14,9 +16,16 @@ const config = defineConfig([
   },
   f1BaseConfig,
   f1StorybookConfig,
+  ...f1ReactConfig.map((reactConfig) => ({
+    ...reactConfig,
+    files: reactConfig.files ?? reactFiles,
+  })),
   {
-    files: ['**/*.tsx', '**/*.jsx'],
-    extends: [f1ReactConfig],
+    files: reactFiles,
+    rules: {
+      // PropTypes are not used; TSX files use types and JSX files are Storybook-only.
+      'react/prop-types': 'off',
+    },
   },
   {
     // allow require() in webpack config files, which use CommonJS,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "watch-design-tokens": "webpack watch --config ./webpack.theme-config.js --mode=development",
     "watch-react": "webpack watch --config ./webpack.react-config.js",
     "watch": "npm run start && concurrently --raw \"npm:watch-theme\" \"npm:watch-design-tokens\" \"npm:watch-react\"",
-    "eslint": "eslint source/**/!\\(*.stories\\).js",
+    "eslint": "eslint \"source/**/!(*.stories).{js,jsx,ts,tsx}\"",
     "stylelint": "stylelint \"source/**/*.scss\"",
     "build-storybook": "npm run build && storybook build -o storybook",
     "dev": "npm run start && concurrently --raw \"npm:watch-theme\" \"npm:watch-design-tokens\" \"npm:watch-react\" \"npm:storybook\"",

--- a/source/05-pages/page-wrappers/default.jsx
+++ b/source/05-pages/page-wrappers/default.jsx
@@ -19,7 +19,6 @@ import { Copyright } from '../../03-components/copyright/copyright.stories.jsx';
 import { BackToTop } from '../../03-components/back-to-top/back-to-top.stories.jsx';
 
 const PageWrapper = props => {
-  // eslint-disable-next-line react/prop-types
   const { children, isHomepage } = props;
   if (isHomepage) {
     document.body.classList.add('front');


### PR DESCRIPTION
Summary: Expands npm run eslint to lint js, jsx, ts, and tsx (matching Webpack), and fixes the ESLint config so React files don’t crash linting.

Why: The npm script only covered .js, so React/TS source wasn’t checked by npm test even though Webpack was already linting those files. Config updates scope the React rules correctly and exclude source/@types/** and story files.

Changes
package.json

Updated the eslint script from JS-only to js, jsx, ts, and tsx
Uses a quoted glob with a !(*.stories) exclusion so Storybook story files are skipped (same intent as before, but now covers React/TS files too)
eslint.config.js

Added source/@types/** to globalIgnores so declaration files aren’t linted
Replaced extends: [f1ReactConfig] with spreading the React config and scoping it to **/*.{jsx,tsx} — this avoids a react-hooks plugin redefinition error when ESLint walks the source/ tree
Disabled react/prop-types for JSX/TSX files, since the theme uses TypeScript types (and Storybook-only JSX) rather than PropTypes
source/05-pages/page-wrappers/default.jsx

Removed an unused eslint-disable-next-line react/prop-types comment after the rule was turned off globally for JSX/TSX
Why
Webpack was already linting js, jsx, ts, and tsx during dev/production builds, but npm run eslint / npm test only targeted .js files. That meant React and TypeScript source could pass CI-style linting while still failing (or never being checked) via the npm script.

The ESLint config changes were needed to make that broader scope work reliably — especially for .jsx/.tsx files, where the previous extends-based React config caused ESLint to crash with a react-hooks plugin conflict during directory traversal.